### PR TITLE
Tests for MintShop1155, Super1155, Staker, Notary with base Contract …

### DIFF
--- a/contracts/MintShop1155.sol
+++ b/contracts/MintShop1155.sol
@@ -15,6 +15,7 @@ import "./Staker.sol";
   @title A Shop contract for selling NFTs via direct minting through particular
     pools with specific participation requirements.
   @author Tim Clancy
+  @author Qazawat Zirak
 
   This launchpad contract sells new items by minting them into existence. It
   cannot be used to sell items that already exist.
@@ -678,14 +679,14 @@ contract MintShop1155 is Sweepable, ReentrancyGuard {
   */
   function getWhitelistStatus(uint256[] calldata _ids,
     address[] calldata _addresses) external view returns (bool[][] memory) {
-    bool[][] memory whitelistStatus;
-    for (uint256 i = 0; i < _ids.length; i++) {
-      uint256 id = _ids[i];
-      uint256 whitelistVersion = whitelists[id].currentWhitelistVersion;
-      for (uint256 j = 0; j < _addresses.length; j++) {
-        bytes32 addressKey = keccak256(abi.encode(whitelistVersion,
-          _addresses[j]));
-        whitelistStatus[j][i] = whitelists[id].addresses[addressKey];
+    bool[][] memory whitelistStatus = new bool[][](_addresses.length);
+    for (uint256 i = 0; i < _addresses.length; i++) {
+      whitelistStatus[i] = new bool[](_ids.length);
+      for (uint256 j = 0; j < _ids.length; j++) {
+        uint256 id = _ids[j];
+        uint256 whitelistVersion = whitelists[id].currentWhitelistVersion;
+        bytes32 addressKey = keccak256(abi.encode(whitelistVersion, _addresses[i]));
+        whitelistStatus[i][j] = whitelists[id].addresses[addressKey];
       }
     }
     return whitelistStatus;
@@ -752,12 +753,13 @@ contract MintShop1155 is Sweepable, ReentrancyGuard {
   */
   function getPurchaseCounts(uint256[] calldata _ids,
     address[] calldata _purchasers) external view returns (uint256[][] memory) {
-    uint256[][] memory purchaseCounts;
-    for (uint256 i = 0; i < _ids.length; i++) {
-      uint256 id = _ids[i];
-      for (uint256 j = 0; j < _purchasers.length; j++) {
-        address purchaser = _purchasers[j];
-        purchaseCounts[j][i] = pools[id].purchaseCounts[purchaser];
+    uint256[][] memory purchaseCounts = new uint256[][](_purchasers.length);
+    for (uint256 i = 0; i < _purchasers.length; i++) {
+      purchaseCounts[i] = new uint256[](_ids.length);
+      for (uint256 j = 0; j < _ids.length; j++) {
+        uint256 id = _ids[j];
+        address purchaser = _purchasers[i];
+        purchaseCounts[i][j] = pools[id].purchaseCounts[purchaser];
       }
     }
     return purchaseCounts;

--- a/contracts/Staker.sol
+++ b/contracts/Staker.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 /**
   @title An asset staking contract.
   @author Tim Clancy
+  @author Qazawat Zirak
 
   This staking contract disburses tokens from its internal reservoir according
   to a fixed emission schedule. Assets can be assigned varied staking weights.
@@ -212,7 +213,7 @@ contract Staker is Ownable, ReentrancyGuard {
         }
       }
     }
-    require(tokenEmissionBlockCount > 0,
+    require(pointEmissionBlockCount > 0,
       "You must set the point emission schedule.");
   }
 

--- a/contracts/base/Sweepable.sol
+++ b/contracts/base/Sweepable.sol
@@ -11,6 +11,7 @@ import "../access/PermitControl.sol";
   @title A base contract which supports an administrative sweep function wherein
     authorized callers may transfer ERC-20 tokens out of this contract.
   @author Tim Clancy
+  @author Qazawat Zirak
 
   This is a base contract designed with the intent to support rescuing ERC-20
   tokens which users might have wrongly sent to a contract.
@@ -67,7 +68,7 @@ contract Sweepable is PermitControl {
     hasValidPermit(UNIVERSAL, SWEEP) {
     require(!sweepLocked,
       "MintShop1155: the sweep function is locked");
-    _token.safeTransferFrom(address(this), _address, _amount);
+    _token.safeTransfer(_address, _amount);
     emit TokenSweep(_msgSender(), _token, _amount, _address);
   }
 

--- a/contracts/test/MockERC1155Receivers.sol
+++ b/contracts/test/MockERC1155Receivers.sol
@@ -1,0 +1,130 @@
+pragma solidity 0.7.6;
+
+import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+
+// Response is Selector
+contract MockERC1155Receiver1 is IERC1155Receiver {
+    constructor() {
+	}
+
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+        )
+        external
+        override
+        returns(bytes4)
+        {//0x0000000000000000000000000000000100000000000000000000000000000001 // id of the token transfered from Super1155
+            if (id == 0x03e700000000000000000000000000000000) { // arbitrary fail trigger for testing
+                return bytes4('Fu');
+            } else {
+                return this.onERC1155Received.selector;
+            }
+        }
+
+        // Assuming there is only one token in the ids
+        function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    ) external override returns (bytes4) {
+        //0x0000000000000000000000000000000100000000000000000000000000000001 // id of the token transfered from Super1155
+            if (ids[0] == 0x03e700000000000000000000000000000000) { // arbitrary fail trigger for testing
+                return bytes4('Fu');
+            } else {
+                return this.onERC1155BatchReceived.selector;
+            }
+
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IERC165).interfaceId;
+    }
+}
+
+// Response is not a selector
+contract MockERC1155Receiver2 is IERC1155Receiver {
+    constructor() {
+	}
+
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+        )
+        external
+        override
+        returns(bytes4)
+        {
+            if (id == 0x03e700000000000000000000000000000000) { // arbitrary fail trigger for testing
+                return bytes4('Fu');
+            } else {
+                return "test";
+            }
+        }
+
+        // Assuming there is only one token in the ids
+        function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    ) external override returns (bytes4) {
+            if (ids[0] == 0x03e700000000000000000000000000000000) { // arbitrary fail trigger for testing
+                return bytes4('Fu');
+            } else {
+                return "test";
+            }
+    }
+
+    function supportsInterface(bytes4 interfaceId) public override view virtual  returns (bool) {
+        return interfaceId == type(IERC165).interfaceId;
+    }
+}
+
+// Response is an error
+contract MockERC1155Receiver3 {
+    constructor() {
+	}
+
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+        )
+        external
+        pure
+
+        {
+ 
+        }
+
+        // Assuming there is only one token in the ids
+        function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    ) external  returns (bytes4) {
+            if (ids[0] == 0x03e700000000000000000000000000000000) { // arbitrary fail trigger for testing
+                return bytes4('Fu');
+            } else {
+                return "test";
+            }
+    }
+
+    function supportsInterface(bytes4 interfaceId) public  view virtual  returns (bool) {
+        return interfaceId == type(IERC165).interfaceId;
+    }
+}

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.7.6;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20("MockERC20", "M20"){
+    constructor() {
+        _mint(msg.sender, 10000000 * 10 ** 18); //Initial Supply
+    }
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "ethereum-waffle": "^3.1.1",
     "ethers": "^5.0.25",
-    "hardhat": "^2.0.10",
+    "hardhat": "^2.6.2",
     "hardhat-contract-sizer": "^2.0.2",
     "hardhat-gas-reporter": "^1.0.4",
     "husky": "^4.3.0",

--- a/test/MintShop1155.test.js
+++ b/test/MintShop1155.test.js
@@ -1,0 +1,1199 @@
+const { expect } = require('chai');
+const { BigNumber } = require('ethers');
+const { mnemonicToSeed } = require('ethers/lib/utils');
+const { ethers } = require('hardhat');
+const Web3 = require('web3');
+
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const DATA = "0x02";
+
+///////////////////////////////////////////////////////////
+// SEE https://hardhat.org/tutorial/testing-contracts.html
+// FOR HELP WRITING TESTS
+// USE https://github.com/gnosis/mock-contract FOR HELP
+// WITH MOCK CONTRACT
+///////////////////////////////////////////////////////////
+
+// Start test block
+describe('===MintShop1155, PermitControl, Sweepable===', function () {
+    let deployer, owner, paymentReceiver, proxyRegistryOwner, signer1, signer2, signer3;
+    let UNIVERSAL,
+        MANAGER,
+        zeroRight,
+
+        setSweepRight, 
+        setLockSweepRight,
+
+        setPaymentReceiverRight,
+        setLockPaymentReceiverRight,
+        setUpdateGlobalLimitRight,
+        setLockGlobalLimitRight,
+        setWhiteListRight,
+        setPoolRight,
+
+        setMintRight;
+
+    let mintShop1155;
+    let super1155;
+    let mockERC20;
+    let staker;
+    let proxyRegistry;
+    const originalUri = "://ipfs/uri/{id}";
+    let itemGroupId = ethers.BigNumber.from(1);
+    let shiftedItemGroupId = itemGroupId.shl(128);
+    let itemGroupId2 = ethers.BigNumber.from(2);
+    let shiftedItemGroupId2 = itemGroupId2.shl(128);
+
+    before(async function () {
+        this.MintShop1155 = await ethers.getContractFactory("MintShop1155");
+        this.MockERC20 = await ethers.getContractFactory("MockERC20");
+        this.Staker = await ethers.getContractFactory("Staker");
+        this.ProxyRegistry = await ethers.getContractFactory("ProxyRegistry");
+        this.Super1155 = await ethers.getContractFactory("Super1155");
+    });
+
+    beforeEach(async function () {
+        [deployer, owner, paymentReceiver, proxyRegistryOwner, signer1, signer2, signer3] = await ethers.getSigners();
+
+        proxyRegistry = await this.ProxyRegistry.deploy();
+        await proxyRegistry.deployed();
+        await proxyRegistry.transferOwnership(proxyRegistryOwner.address);
+
+        super1155 = await this.Super1155.deploy(
+            owner.address,
+            "Super1155",
+            originalUri,
+            proxyRegistry.address
+        );
+        await super1155.deployed();
+
+        mintShop1155 = await this.MintShop1155.deploy(
+            owner.address,
+            super1155.address,
+            paymentReceiver.address,
+            "4"
+        );
+        await mintShop1155.deployed();
+
+        mockERC20 = await this.MockERC20.deploy();
+        await mockERC20.deployed();
+
+        staker = await this.Staker.deploy(
+            "firstStaker",
+            mockERC20.address
+        );
+        await staker.transferOwnership(owner.address);
+
+        UNIVERSAL = await mintShop1155.UNIVERSAL();
+        MANAGER = await mintShop1155.MANAGER();
+        zeroRight = await mintShop1155.ZERO_RIGHT();
+
+        setSweepRight = await mintShop1155.SWEEP();
+        setLockSweepRight = await mintShop1155.LOCK_SWEEP();
+
+        setPaymentReceiverRight = await mintShop1155.SET_PAYMENT_RECEIVER();
+        setLockPaymentReceiverRight = await mintShop1155.LOCK_PAYMENT_RECEIVER();
+        setUpdateGlobalLimitRight = await mintShop1155.UPDATE_GLOBAL_LIMIT();
+        setLockGlobalLimitRight = await mintShop1155.LOCK_GLOBAL_LIMIT();
+        setWhiteListRight = await mintShop1155.WHITELIST();
+        setPoolRight = await mintShop1155.POOL();
+
+        setMintRight = await super1155.MINT();
+    });
+
+    // Test cases
+
+    //////////////////////////////
+    //       Constructor
+    //////////////////////////////
+    describe("Constructor", function () {
+        it('should initialize values as expected', async function () {
+            expect(await mintShop1155.owner()).to.equal(owner.address);
+            expect(await mintShop1155.item()).to.equal(super1155.address);
+            expect(await mintShop1155.paymentReceiver()).to.equal(paymentReceiver.address);
+            expect(await mintShop1155.globalPurchaseLimit()).to.equal("4");
+        });
+
+        it('should deploy a new instance where deployer is the owner', async function () {
+            let mintShop1155v2 = await this.MintShop1155.deploy(
+                deployer.address,
+                super1155.address,
+                paymentReceiver.address,
+                "4"
+            );
+            await super1155.deployed();
+
+            expect(await mintShop1155v2.owner()).to.equal(deployer.address);
+            expect(await mintShop1155v2.item()).to.equal(super1155.address);
+            expect(await mintShop1155v2.paymentReceiver()).to.equal(paymentReceiver.address);
+            expect(await mintShop1155v2.globalPurchaseLimit()).to.equal("4");
+        });
+    });
+
+    describe("version", function () {
+        it('should return the correct version', async function(){
+            expect(await mintShop1155.version()).to.equal(1)
+        });
+    });
+
+    describe("updatePaymentReceiver", function () {
+        it('Reverts: payment receiver address is locked', async function(){
+            await mintShop1155.connect(owner).lockPaymentReceiver();
+            await expect(
+                mintShop1155.connect(owner).updatePaymentReceiver(owner.address)
+            ).to.be.revertedWith("MintShop1155: the payment receiver address is locked");
+        });
+
+        it('Reverts: no valid permit', async function(){
+            await expect(
+                mintShop1155.connect(deployer).updatePaymentReceiver(owner.address)
+            ).to.be.revertedWith("PermitControl: sender does not have a valid permit");
+        });
+
+        it('Reverts: setting manager for Zero address', async function(){
+            let input = {
+                types: ["address"],
+                values: [deployer.address]
+            }
+
+            await expect(
+                mintShop1155.connect(owner).setManagerRight(zeroRight, ethers.utils.defaultAbiCoder.encode(input.types, input.values))
+            ).to.be.revertedWith("PermitControl: you may not specify a manager for the zero right");
+        });
+
+        it('should test PermitControl to set a manager who can further create permits to update payment receiver', async function(){
+            // Declare a rights relationship for manager => payment
+            await mintShop1155.connect(owner).setManagerRight(setPaymentReceiverRight, MANAGER);
+
+            // Give a manager a permit
+            await mintShop1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                MANAGER,
+                ethers.constants.MaxUint256
+            );
+            
+            // Give a manager a payment permit
+            await mintShop1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                setPaymentReceiverRight,
+                ethers.constants.MaxUint256
+            );
+
+            // That manager creates a further permit for signer1 to update payment
+            await mintShop1155.connect(deployer).setPermit(
+                signer1.address,
+                UNIVERSAL,
+                setPaymentReceiverRight,
+                ethers.constants.MaxUint256
+            );
+             
+            await mintShop1155.connect(signer1).updatePaymentReceiver(owner.address);
+            expect(await mintShop1155.paymentReceiver()).to.equal(owner.address);
+
+            await mintShop1155.connect(signer1).updatePaymentReceiver(paymentReceiver.address);
+            expect(await mintShop1155.paymentReceiver()).to.equal(paymentReceiver.address);
+        });
+    });
+
+    describe("updateGlobalPurchaseLimit", function () {
+        it('Reverts: global purchase limit is locked', async function(){
+            await mintShop1155.connect(owner).lockGlobalPurchaseLimit();
+
+            await expect(
+                mintShop1155.connect(owner).updateGlobalPurchaseLimit("6")
+            ).to.be.revertedWith("MintShop1155: the global purchase limit is locked");
+        });
+
+        it('should update global purchase limit', async function(){
+            await mintShop1155.connect(owner).updateGlobalPurchaseLimit("6");
+        });
+    });
+
+    describe("addWhiteList, updateWhitelist", function () {
+        it('should add a whitelist', async function(){
+            await mintShop1155.connect(owner).addWhitelist({
+                expiryTime: ethers.constants.MaxUint256,
+                isActive: false,
+                addresses: [signer1.address]
+            });
+
+            await expect(
+                await mintShop1155.connect(owner).nextWhitelistId()
+            ).to.be.equal("2");
+        });
+
+        it('should edit a whitelist', async function(){
+            // Add the whitelist
+            await mintShop1155.connect(owner).addWhitelist({
+                expiryTime: ethers.constants.MaxUint256,
+                isActive: false,
+                addresses: [signer1.address]
+            });
+
+            await expect(
+                await mintShop1155.connect(owner).nextWhitelistId()
+            ).to.be.equal("2");
+
+            // Edit the whitelist
+            await mintShop1155.connect(owner).updateWhitelist(0,{
+                expiryTime: ethers.constants.MaxUint256,
+                isActive: true,
+                addresses: [signer1.address]
+            });
+
+            await expect(
+                await mintShop1155.connect(owner).nextWhitelistId()
+            ).to.be.equal("2");
+        });
+    });
+
+    describe("addToWhitelist, getWhitelistStatus", function () {
+        it('should add addresses to whitelist', async function(){
+            // Create a whitelist with signer1 whitelisted
+            await mintShop1155.connect(owner).addWhitelist({
+                expiryTime: ethers.constants.MaxUint256,
+                isActive: false,
+                addresses: [signer1.address]
+            });
+
+            // Add more addresses to the whitelist including already existing one
+            await mintShop1155.connect(owner).addToWhitelist(
+                1,
+                [signer1.address, signer2.address, signer3.address]
+            );
+
+            let result = await mintShop1155.connect(owner).getWhitelistStatus([1], [signer1.address, signer2.address, owner.address]);
+
+            await expect(result[0][0]).to.be.equal(true); // First index is the addresses, second whitelists
+            await expect(result[1][0]).to.be.equal(true); // First index is the addresses, second whitelists
+            await expect(result[2][0]).to.be.equal(false); // First index is the addresses, second whitelists
+        });
+    });
+
+    describe("removeFromWhitelist", function () {
+        it('should remove addresses from whitelist', async function(){
+            // Create a whitelist with signer1 whitelisted
+            await mintShop1155.connect(owner).addWhitelist({
+                expiryTime: ethers.constants.MaxUint256,
+                isActive: false,
+                addresses: [signer1.address]
+            });
+
+            // Add more addresses to the whitelist including already existing one
+            await mintShop1155.connect(owner).addToWhitelist(
+                1,
+                [signer1.address, signer2.address, signer3.address]
+            );
+            
+            // Get the addresses that are in the whitelist
+            let result = await mintShop1155.connect(owner).getWhitelistStatus([1], [signer1.address, signer3.address, owner.address, signer2.address]);
+
+            // Expect their presence
+            await expect(result[0][0]).to.be.equal(true); // First index is the addresses, second whitelists
+            await expect(result[1][0]).to.be.equal(true); // First index is the addresses, second whitelists
+            await expect(result[2][0]).to.be.equal(false); // First index is the addresses, second whitelists
+            await expect(result[3][0]).to.be.equal(true); // First index is the addresses, second whitelists
+
+            // Remove one address from whitelist
+            await mintShop1155.connect(owner).removeFromWhitelist(1, [signer1.address]);
+
+            // Reload the addresses that are in the whitelist
+            result = await mintShop1155.connect(owner).getWhitelistStatus([1], [signer1.address, signer3.address]);
+
+            // Expect the absence
+            await expect(result[0][0]).to.be.equal(false); // First index is the addresses, second whitelists
+            await expect(result[1][0]).to.be.equal(true); // First index is the addresses, second whitelists
+        });
+    });
+
+    describe("setWhitelistActive", function () {
+        it('should return the correct version', async function(){
+            // Create a whitelist with signer1 whitelisted
+            await mintShop1155.connect(owner).addWhitelist({
+                expiryTime: ethers.constants.MaxUint256,
+                isActive: false,
+                addresses: [signer1.address]
+            });
+
+            let whitelist = await mintShop1155.whitelists(1);
+            await expect(
+                whitelist.isActive
+            ).to.be.equal(false);
+
+            // Set the whitelist status to active
+            await mintShop1155.connect(owner).setWhitelistActive(1, true);
+
+            whitelist = await mintShop1155.whitelists(1);
+            await expect(
+                whitelist.isActive
+            ).to.be.equal(true);
+        });
+    });
+
+    describe("updatePool, addPool, getPools", function () {
+        beforeEach(async function(){
+            // Configure token groups
+            await super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'FUNGIBLE',
+                supplyType: 1,
+                supplyData: 10,
+                itemType: 1,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            });
+
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'NONFUNGIBLE',
+                supplyType: 0,
+                supplyData: 1,
+                itemType: 0,
+                itemData: 0,
+                burnType: 0,
+                burnData: 0
+            });
+        });
+
+        it('Reverts: updatePool a non-existent pool', async function(){
+            // Updating a pool with non-existent pool id
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await expect(mintShop1155.connect(owner).updatePool(1, {
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 5,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 1
+                }
+            }, [1], [1], [1], [[{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }]])).to.be.revertedWith("MintShop1155: cannot update a non-existent pool");
+        });
+
+        it('Reverts: updatePool end time preceeds start time', async function(){
+            // Updating a pool with endTime preceeding startTime
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await expect(mintShop1155.connect(owner).updatePool(0, {
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp - 60,
+                purchaseLimit: 5,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 1
+                }
+            }, [1], [1], [1], [[{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }]])).to.be.revertedWith("MintShop1155: cannot create a pool which ends before it starts");
+        });
+
+        it('Reverts: updatePool no item groups included', async function(){
+            // Updating a pool with 0 groups
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await expect(mintShop1155.connect(owner).updatePool(0, {
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 5,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 1
+                }
+            }, [], [1], [1], [[{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }]])).to.be.revertedWith("MintShop1155: must list at least one item group");
+        });
+
+        it('Reverts: updatePool groups and offsets length mismatch', async function(){
+            // Updating a pool with groups and offsets length mismatch
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await expect(mintShop1155.connect(owner).updatePool(0, {
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 5,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 1
+                }
+            }, [1], [1, 2], [1], [[{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }]])).to.be.revertedWith("MintShop1155: item groups length must equal issue offsets length");
+        });
+
+        it('Reverts: updatePool groups and caps length mismatch', async function(){
+            // Updating a pool with groups and caps length mismatch
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await expect(mintShop1155.connect(owner).updatePool(0, {
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 5,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 1
+                }
+            }, [1], [1], [1, 2], [[{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }]])).to.be.revertedWith("MintShop1155: item groups length must equal caps length");
+        });
+
+        it('Reverts: updatePool groups and prices length mismatch', async function(){
+            // Updating a pool with groups and prices length mismatch
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await expect(mintShop1155.connect(owner).updatePool(0, {
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 5,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 1
+                }
+            }, [1, 2], [1, 2], [1, 2], [[{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }]])).to.be.revertedWith("MintShop1155: item groups length must equal prices input length");
+        });
+
+        it('Reverts: updatePool no mintable amount', async function(){
+            // Updating a pool with no mintable amount
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await expect(mintShop1155.connect(owner).updatePool(0, {
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 5,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 1
+                }
+            }, [1], [1], [0], [[{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }]])).to.be.revertedWith("MintShop1155: cannot add an item group with no mintable amount");
+        });
+
+        it('should add a pool, update it, get the pool', async function(){
+            // Creating a pool
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await mintShop1155.connect(owner).addPool({
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 5,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 1
+                }
+            }, [1, 2], [1, 1], [10, 1], [[{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }], [{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }]]);
+
+            // Updating the purchase limit to 1
+            latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await mintShop1155.connect(owner).updatePool(0, {
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 1,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 1
+                }
+            }, [1, 2], [1, 1], [10, 1], [[{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }], [{
+                assetType: 1,
+                asset: NULL_ADDRESS,
+                price: 1
+            }]]);
+
+            //Get the pool
+            let pools = await mintShop1155.connect(owner).getPools([0]);
+            expect(pools[0].name).to.be.equal("firstPool");
+        });
+    });
+
+    describe("mintFromPool, getPoolsWithAddress, getPurchaseCounts", function () {
+        beforeEach(async function(){
+            // Configure token groups
+            await super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'FUNGIBLE',
+                supplyType: 1,
+                supplyData: 10,
+                itemType: 1,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            });
+
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'NFT',
+                supplyType: 0,
+                supplyData: 5,
+                itemType: 0,
+                itemData: 0,
+                burnType: 0,
+                burnData: 0
+            });
+
+            await super1155.connect(owner).configureGroup(itemGroupId2.add(1), {
+                name: 'SUPERNFT',
+                supplyType: 0,
+                supplyData: 5,
+                itemType: 0,
+                itemData: 0,
+                burnType: 0,
+                burnData: 0
+            });
+
+            // Create Pools
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await mintShop1155.connect(owner).addPool({
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 3,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 0
+                    }
+                }, [1, 2], // Groups 1 = FT, 2 = NFT
+                [1, 0], // NumberOffset 1 = FT, 0 = NFT // FT's are coerced to index 1
+                [10, 5], // Caps 10 = FT, 5 = NFT
+                [
+                    [{ // Price pair for FTs
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }], 
+
+                    [{ // Price pairs for NFTs, 5 NFTs = 5 Prices Pairs
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }, {
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }, {
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }, {
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }, {
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }]
+                ]);
+
+            latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await mintShop1155.connect(owner).addPool({
+                name: "secondPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 2,
+                singlePurchaseLimit: 1,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 0
+                    }
+                }, [3], // Group
+                [0], // NumberOffset
+                [2], // Caps
+                [
+                    [{ // Price pairs
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }, {
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }]
+                ]);
+
+            // Get the pool
+            let pools = await mintShop1155.connect(owner).getPools([0]);
+            expect(pools[0].name).to.be.equal("firstPool");
+        });
+
+        it('Reverts: mintFromPool amount less than 0', async function(){
+            // Mint from pool
+            await expect(
+                mintShop1155.connect(owner).mintFromPool(0, 2, 1, 0)
+            ).to.be.revertedWith("MintShop1155: must purchase at least one item");
+        });
+
+        it('Reverts: mintFromPool pool not active', async function(){
+            // Mint from pool
+            await expect(
+                mintShop1155.connect(owner).mintFromPool(2, 2, 1, 1)
+            ).to.be.revertedWith("MintShop1155: can only purchase items from an active pool");
+        });
+
+        it('Reverts: mintFromPool amount greater than singlePurchaseLimit', async function(){
+            // Mint from pool
+            await expect(
+                mintShop1155.connect(owner).mintFromPool(0, 2, 1, 3)
+            ).to.be.revertedWith("MintShop1155: cannot exceed the per-transaction maximum");
+        });
+
+        it('Reverts: mintFromPool assetindex not valid', async function(){
+            // Mint from pool
+            await expect(
+                mintShop1155.connect(owner).mintFromPool(0, 2, 5, 1)
+            ).to.be.revertedWith("MintShop1155: specified asset index is not valid");
+        });
+
+        it('Reverts: mintFromPool pool is not running', async function(){
+            // Jump forward in time more than the pool end time
+            await ethers.provider.send("evm_increaseTime", [70]);
+            await ethers.provider.send("evm_mine", []);
+
+            // Mint from pool
+            await expect(
+                mintShop1155.connect(owner).mintFromPool(0, 2, 0, 1)
+            ).to.be.revertedWith("MintShop1155: pool is not currently running its sale");
+        });
+
+        it('Reverts: mintFromPool pool purchase limit reach', async function(){
+            // Give the Shop permit to mint items in Super1155 contract
+            await super1155.connect(owner).setPermit(
+                mintShop1155.address,
+                UNIVERSAL,
+                setMintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // Mint three times
+            await mintShop1155.connect(owner).mintFromPool(0, 2, 0, 1, {value: ethers.utils.parseEther("1")})
+            await mintShop1155.connect(owner).mintFromPool(0, 2, 1, 1, {value: ethers.utils.parseEther("1")})
+            await mintShop1155.connect(owner).mintFromPool(0, 2, 2, 1, {value: ethers.utils.parseEther("1")})
+
+            // Mint again surpassing the purchase limit of the pool
+            await expect(
+                mintShop1155.connect(owner).mintFromPool(0, 2, 0, 1, {value: ethers.utils.parseEther("1")})
+            ).to.be.revertedWith("MintShop1155: you may not purchase any more items from this pool");
+        });
+
+        it('Reverts: mintFromPool global purchase limit reach', async function(){
+            // Give the Shop permit to mint items in Super1155 contract
+            await super1155.connect(owner).setPermit(
+                mintShop1155.address,
+                UNIVERSAL,
+                setMintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // Mint four times
+            await mintShop1155.connect(owner).mintFromPool(0, 2, 0, 1, {value: ethers.utils.parseEther("1")})
+            await mintShop1155.connect(owner).mintFromPool(0, 2, 1, 1, {value: ethers.utils.parseEther("1")})
+            await mintShop1155.connect(owner).mintFromPool(0, 2, 2, 1, {value: ethers.utils.parseEther("1")})
+            await mintShop1155.connect(owner).mintFromPool(1, 3, 0, 1, {value: ethers.utils.parseEther("1")})
+
+            // Mint again surpassing the global purchase limit
+            await expect(
+                mintShop1155.connect(owner).mintFromPool(1, 3, 1, 1, {value: ethers.utils.parseEther("1")})
+            ).to.be.revertedWith("MintShop1155: you may not purchase any more items from this shop");
+        });
+
+        it('Reverts: mintFromPool not whitelisted in the pool', async function(){
+            // Give the Shop permit to mint items in Super1155 contract
+            await super1155.connect(owner).setPermit(
+                mintShop1155.address,
+                UNIVERSAL,
+                setMintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // Create whitelist with deployer's address in it
+            await mintShop1155.connect(owner).addWhitelist({
+                expiryTime: ethers.constants.MaxUint256,
+                isActive: false,
+                addresses: [deployer.address]
+            });
+
+            // Set the whitelist status to active
+            await mintShop1155.connect(owner).setWhitelistActive(1, true);
+
+            // Update the pool from beforeEach to include whitelist
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await mintShop1155.connect(owner).updatePool(1, {
+                name: "secondPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 2,
+                singlePurchaseLimit: 1,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 1
+                    }
+                }, [3], // Group
+                [0], // NumberOffset
+                [2], // Caps
+                [
+                    [{ // Price pairs
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }, {
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }]
+                ]);
+           
+            // Mint
+            await expect(
+                mintShop1155.connect(signer1).mintFromPool(1, 3, 0, 1, {value: ethers.utils.parseEther("1")})
+            ).to.be.revertedWith("MintShop1155: you are not whitelisted on this pool");
+        });
+
+        it('Reverts: mintFromPool not enough items available for purchase', async function(){
+            // Give the Shop permit to mint items in Super1155 contract
+            await super1155.connect(owner).setPermit(
+                mintShop1155.address,
+                UNIVERSAL,
+                setMintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // Update the pool from beforeEach to lower its cap
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await mintShop1155.connect(owner).updatePool(1, {
+                name: "secondPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 2,
+                singlePurchaseLimit: 1,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 0
+                    }
+                }, [3], // Group
+                [0], // NumberOffset
+                [1], // Caps
+                [
+                    [{ // Price pairs
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }, {
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }]
+                ]);
+           
+            await mintShop1155.connect(signer1).mintFromPool(1, 3, 0, 1, {value: ethers.utils.parseEther("1")})
+
+            // Mint until cap reached
+            await expect(
+                mintShop1155.connect(signer1).mintFromPool(1, 3, 0, 1, {value: ethers.utils.parseEther("1")})
+            ).to.be.revertedWith("MintShop1155: there are not enough items available for you to purchase");
+        });
+
+        it('Reverts: not enough ether sent', async function(){
+
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await mintShop1155.connect(owner).updatePool(1, {
+                name: "secondPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 2,
+                singlePurchaseLimit: 1,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 0
+                    }
+                }, [3], // Group
+                [0], // NumberOffset
+                [2], // Caps
+                [
+                    [{ // Price pairs
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: ethers.utils.parseEther("1")
+                    }, {
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }]
+                ]);
+
+            // Give the Shop permit to mint items in Super1155 contract
+            await super1155.connect(owner).setPermit(
+                mintShop1155.address,
+                UNIVERSAL,
+                setMintRight,
+                ethers.constants.MaxUint256
+            );
+
+            await expect(
+                mintShop1155.connect(owner).mintFromPool(1, 3, 0, 1, {value: ethers.utils.parseEther("0.5")})
+            ).to.be.revertedWith("MintShop1155: you did not send enough Ether to complete the purchase");
+        });
+
+        it('Reverts => Success: mintFromPool not enough ERC20 tokens for the pool & the purchase', async function(){
+            // Give the Shop permit to mint items in Super1155 contract
+            await super1155.connect(owner).setPermit(
+                mintShop1155.address,
+                UNIVERSAL,
+                setMintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // Update the pool from beforeEach to include ERC20 token as price pair
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await mintShop1155.connect(owner).updatePool(1, {
+                name: "secondPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 4,
+                singlePurchaseLimit: 3,
+                requirement: {
+                    requiredType: 1,
+                    requiredAsset: mockERC20.address,
+                    requiredAmount: ethers.utils.parseEther("10"),
+                    whitelistId: 0
+                    }
+                }, [3], // Group
+                [0], // NumberOffset
+                [5], // Caps
+                [
+                    [{ // Price pairs
+                        assetType: 2,
+                        asset: mockERC20.address,
+                        price: ethers.utils.parseEther("15")
+                    }, {
+                        assetType: 2,
+                        asset: mockERC20.address,
+                        price: ethers.utils.parseEther("15")
+                    }]
+                ]);
+           
+            // Give signer1 some amount of ERC20 Tokens
+            await mockERC20.connect(deployer).transfer(signer1.address, ethers.utils.parseEther("5"));
+
+            // Mint until cap reached
+            await expect(
+                mintShop1155.connect(signer1).mintFromPool(1, 3, 0, 1)
+            ).to.be.revertedWith("MintShop1155: you do not have enough required token for this pool");
+
+            // Give signer1 some more amount of ERC20 Tokens
+            await mockERC20.connect(deployer).transfer(signer1.address, ethers.utils.parseEther("5"));
+
+            // Signer1 approves mintshop1155 contract
+            await mockERC20.connect(signer1).approve(mintShop1155.address, ethers.utils.parseEther("15"));
+
+            await expect(
+                mintShop1155.connect(signer1).mintFromPool(1, 3, 1, 3)
+            ).to.be.revertedWith("MintShop1155: you do not have enough token to complete the purchase");
+
+            // Successful purchase, Give signer1 some more amount of ERC20 Tokens
+            await mockERC20.connect(deployer).transfer(signer1.address, ethers.utils.parseEther("5"));
+
+            await mintShop1155.connect(signer1).mintFromPool(1, 3, 1, 1);
+
+            // getPurchaseCounts
+            let balances = await mintShop1155.connect(signer1).getPurchaseCounts([1], [signer1.address, signer2.address, owner.address]);
+
+            await expect(balances[0][0]).to.be.equal("1"); //First index is the address, second is the ids
+            await expect(balances[1][0]).to.be.equal("0"); //First index is the address, second is the ids
+            await expect(balances[2][0]).to.be.equal("0"); //First index is the address, second is the ids
+        });
+
+        it('Reverts: mintFromPool unrecognized asset type (But it gets reverted at the time of assigning instead of actual revert)', async function(){
+            // Give the Shop permit to mint items in Super1155 contract
+            await super1155.connect(owner).setPermit(
+                mintShop1155.address,
+                UNIVERSAL,
+                setMintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // Update the pool from beforeEach to include ERC20 token as price pair
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await expect(
+                mintShop1155.connect(owner).updatePool(1, {
+                name: "secondPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 2,
+                singlePurchaseLimit: 1,
+                requirement: {
+                    requiredType: 0,
+                    requiredAsset: NULL_ADDRESS,
+                    requiredAmount: 1,
+                    whitelistId: 0
+                    }
+                }, [3], // Group
+                [0], // NumberOffset
+                [2], // Caps
+                [
+                    [{ // Price pairs
+                        assetType: 3,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }, {
+                        assetType: 3,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }]
+                ])).to.be.reverted;
+            
+        });
+
+        it('Reverts: not enough ERC1155 required items', async function(){
+            // Give the Shop permit to mint items in Super1155 contract
+            await super1155.connect(owner).setPermit(
+                mintShop1155.address,
+                UNIVERSAL,
+                setMintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // Update the pool from beforeEach to include ERC1155 requirement
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await mintShop1155.connect(owner).updatePool(1, {
+                name: "secondPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 2,
+                singlePurchaseLimit: 1,
+                requirement: {
+                    requiredType: 2,
+                    requiredAsset: super1155.address,
+                    requiredAmount: 1,
+                    whitelistId: 0
+                    }
+                }, [3], // Group
+                [0], // NumberOffset
+                [2], // Caps
+                [
+                    [{ // Price pairs
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }, {
+                        assetType: 1,
+                        asset: NULL_ADDRESS,
+                        price: 1
+                    }]
+                ]);
+
+                // Mint based on ERC1155 item holdings
+                await expect(
+                    mintShop1155.connect(signer1).mintFromPool(1, 3, 1, 1)
+                ).to.be.revertedWith("MintShop1155: you do not have enough required item for this pool");
+
+                // Mint ERC1155 for signer1
+                await super1155.connect(owner).mintBatch(signer1.address, [shiftedItemGroupId], ["1"], DATA);
+
+                await mintShop1155.connect(signer1).mintFromPool(1, 3, 0, 1, {value: ethers.utils.parseEther("1")});
+        });
+
+        it('should getPoolsWithAddress', async function(){
+            // Get all the pools mentioned
+            let pools = await mintShop1155.connect(owner).getPoolsWithAddress([0, 1], owner.address);
+            await expect(
+                pools[0].name
+            ).to.be.equal("firstPool")
+        });
+    });
+
+    describe("mintFromPool for staker contract for a specific Super1155 group", function () {
+        it('should purchase using staking points', async function(){
+            // Configure token group
+            await super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'FUNGIBLE',
+                supplyType: 1,
+                supplyData: 10,
+                itemType: 0,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            });
+
+            // Create Pool of that token group
+            let latestBlock = await ethers.provider.getBlock(await ethers.provider.getBlockNumber());
+            await mintShop1155.connect(owner).addPool({
+                name: "firstPool",
+                startTime: latestBlock.timestamp,
+                endTime: latestBlock.timestamp + 60,
+                purchaseLimit: 3,
+                singlePurchaseLimit: 2,
+                requirement: {
+                    requiredType: 3,
+                    requiredAsset: staker.address,
+                    requiredAmount: 1000, // Required amount of points
+                    whitelistId: 0
+                    }
+                }, [1], // Groups 1 = FT, 2 = NFT
+                [0], // NumberOffset 1 = FT, 0 = NFT // FT's are coerced to index 1
+                [10], // Caps 10 = FT, 5 = NFT
+                [
+                    [{ // Price pair for FTs
+                        assetType: 0,
+                        asset: staker.address,
+                        price: 1
+                    }]
+                ]);
+
+            // Set Emission rate to current block number
+            await staker.connect(owner).setEmissions([
+				{ blockNumber: (await (await ethers.provider.getBlock()).number) +  5, rate: ethers.utils.parseEther('10') },
+			], [
+				{ blockNumber: (await (await ethers.provider.getBlock()).number) +  5, rate: 100 },
+			]);
+			await staker.connect(owner).addPool(mockERC20.address, 100, 50);
+
+			for (let i = 0; i < 4; ++i) {
+				ethers.provider.send('evm_mine');
+			}
+
+            // Give the signer1 some mockERC20 tokens
+            await mockERC20.connect(deployer).transfer(signer1.address, ethers.utils.parseEther("10"));
+
+            // Give staker contract some mockERC20 tokens
+            await mockERC20.connect(deployer).transfer(staker.address, ethers.utils.parseEther("1000"));
+            
+            // Signer1 approves staker contract
+            await mockERC20.connect(signer1).approve(staker.address, ethers.utils.parseEther("10"));
+           
+            // Signer1 deposits the tokens
+            await staker.connect(signer1).deposit(mockERC20.address, ethers.utils.parseEther("10"));
+
+            // Jump forward and travel in time through the portal
+            for (let i = 0; i < 5; ++i) {
+				ethers.provider.send('evm_mine');
+			}
+
+            await expect((
+                await staker.connect(owner).getPendingPoints(mockERC20.address, signer1.address)).toString()
+            ).to.be.equal("500");
+            
+            // Signer1 hasn't claimed points
+            // mintFromPool of mintshop1155 must revert
+            await expect(
+                mintShop1155.connect(signer1).mintFromPool(0, 1, 0, 1)
+            ).to.be.revertedWith("MintShop1155: you do not have enough required points for this pool");
+            
+            // Jump forward and travel in time through the portal, signer1 must be eligible for the pool now
+            for (let i = 0; i < 5; ++i) {
+				ethers.provider.send('evm_mine');
+			}
+
+            // Signer1 withdraws his deposits thus receiving points
+            await staker.connect(signer1).withdraw(mockERC20.address, ethers.utils.parseEther("10"));
+
+            await expect(
+                await staker.connect(signer1).getAvailablePoints(signer1.address)
+            ).to.be.above("1000");
+
+            // Owner of staker contract approves the mintshop1155 to use user points
+            await staker.connect(owner).approvePointSpender(mintShop1155.address, true);
+
+            // Owner of mintshop1155 contract sets a permit for signer1 to mint
+            await super1155.connect(owner).setPermit(
+                mintShop1155.address,
+                UNIVERSAL,
+                setMintRight,
+                ethers.constants.MaxUint256
+            );
+            
+            // Signer1 Successfully mint
+            await mintShop1155.connect(signer1).mintFromPool(0, 1, 0, 1);
+        });
+    });
+
+    describe("sweep, lockSweep", function () {
+        it('Reverts: sweep is locked', async function(){
+            await mintShop1155.connect(owner).lockSweep();
+
+            await expect(
+                mintShop1155.connect(owner).sweep(mockERC20.address, ethers.utils.parseEther("10"), signer1.address)
+            ).to.be.revertedWith("MintShop1155: the sweep function is locked");
+        });
+
+        it('should sweep tokens back from mintshop1155 to the user address', async function(){
+            await mockERC20.connect(deployer).transfer(signer3.address, ethers.utils.parseEther("10"));
+
+            await mockERC20.connect(signer3).transfer(mintShop1155.address, ethers.utils.parseEther("5"));
+
+            await mintShop1155.connect(owner).sweep(mockERC20.address, ethers.utils.parseEther("5"), signer3.address);
+
+            await expect(
+                await mockERC20.balanceOf(signer3.address)
+            ).to.be.equal(ethers.utils.parseEther("10"));
+        });
+    });
+});

--- a/test/Notary.test.js
+++ b/test/Notary.test.js
@@ -1,0 +1,149 @@
+const { expect } = require('chai');
+const { BigNumber } = require('ethers');
+const { mnemonicToSeed } = require('ethers/lib/utils');
+const { ethers } = require('hardhat');
+const Web3 = require('web3');
+
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const DATA = "0x02";
+
+///////////////////////////////////////////////////////////
+// SEE https://hardhat.org/tutorial/testing-contracts.html
+// FOR HELP WRITING TESTS
+// USE https://github.com/gnosis/mock-contract FOR HELP
+// WITH MOCK CONTRACT
+///////////////////////////////////////////////////////////
+
+// Start test block
+describe('===Notary===', function () {
+    let deployer, owner, signer1;
+    
+    let proxyRegistry,
+        super1155,
+        notary;
+    const originalUri = "://ipfs/uri/{id}";
+    let itemGroupId = ethers.BigNumber.from(1);
+    let shiftedItemGroupId = itemGroupId.shl(128);
+    let itemGroupId2 = ethers.BigNumber.from(2);
+    let shiftedItemGroupId2 = itemGroupId2.shl(128);
+
+    before(async function () {
+        this.ProxyRegistry = await ethers.getContractFactory("ProxyRegistry");
+        this.Super1155 = await ethers.getContractFactory("Super1155");
+        this.Notary = await ethers.getContractFactory("Notary");
+    });
+
+    beforeEach(async function () {
+        [deployer, owner, signer1] = await ethers.getSigners();
+
+        // Deploy Proxy Registry
+        proxyRegistry = await this.ProxyRegistry.deploy();
+        await proxyRegistry.deployed();
+
+        // Deploy Super1155 item collection
+        super1155 = await this.Super1155.deploy(
+            owner.address,
+            "Super1155",
+            originalUri,
+            proxyRegistry.address
+        );
+        await super1155.deployed();
+
+        // Notary will be deployed later after creating some item collection
+    });
+
+    // Test cases
+
+    //////////////////////////////
+    //       Constructor
+    //////////////////////////////
+    describe("Constructor", function () {
+        it('should initialize values as expected', async function () {
+            notary = await this.Notary.deploy(
+                super1155.address,
+                [0, 1, 2]  // Initialize dummy token ids
+            );
+
+            expect(await notary.collection()).to.equal(super1155.address);
+            expect(await notary.signatureStatus(1)).to.equal(1);
+            expect(await notary.signatureStatus(3)).to.equal(0);
+        });
+    });
+
+    describe("Sign", function () {
+        beforeEach(async function() {
+            // Create Itemsgroup ID = 1. Remember about Fungible items Index coercion to index 1
+            await super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'FUNGIBLE',
+                    supplyType: 1,
+                    supplyData: 5,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 1,
+                    burnData: 2
+                });
+
+            // Create Itemsgroup ID = 2
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'NFT',
+                    supplyType: 0,
+                    supplyData: 2,
+                    itemType: 0,
+                    itemData: 0,
+                    burnType: 0,
+                    burnData: 0
+                });
+
+            // Mint items in batch to group 1 & 2
+            await super1155.connect(owner).mintBatch(
+                signer1.address, 
+                [shiftedItemGroupId.add(1), shiftedItemGroupId2, shiftedItemGroupId2.add(1)], 
+                ["5", "1", "1"], // FT, NFT, NFT
+                DATA);
+
+            // Create Notary of those items with their IDs
+            notary = await this.Notary.deploy(
+                super1155.address,
+                [shiftedItemGroupId.add(1), shiftedItemGroupId2, shiftedItemGroupId2.add(1)]
+            );
+        });
+
+        it('Reverts: can not sign for no items', async function () {
+            await expect(
+                notary.connect(signer1).sign([])
+            ).to.be.revertedWith("Notary::sign::Must sign for at least one ID");
+        });
+
+        it('Reverts: invalid token id', async function () {
+            await expect(
+                notary.connect(signer1).sign([shiftedItemGroupId.add(2)])
+            ).to.be.revertedWith("Notary::sign::Invalid token ID");
+        });
+
+        it('Reverts: already signed', async function () {
+            await notary.connect(signer1).sign([shiftedItemGroupId.add(1)])
+            await expect(
+                notary.connect(signer1).sign([shiftedItemGroupId.add(1)])
+            ).to.be.revertedWith("Notary::sign::Token ID already signed for");
+        });
+
+        it('should sign for the provided asset id', async function () {
+            await notary.connect(signer1).sign(
+                [shiftedItemGroupId.add(1), shiftedItemGroupId2, shiftedItemGroupId2.add(1)]);
+
+            await expect(
+                await notary.connect(signer1).signed(signer1.address, shiftedItemGroupId.add(1))
+            ).to.be.equal(true);
+            await expect(
+                await notary.connect(signer1).signed(signer1.address, shiftedItemGroupId2)
+            ).to.be.equal(true);
+            await expect(
+                await notary.connect(signer1).signed(signer1.address, shiftedItemGroupId2.add(1))
+            ).to.be.equal(true);
+            await expect(
+                await notary.connect(signer1).signed(signer1.address, shiftedItemGroupId2.add(2))
+            ).to.be.equal(false);
+        });
+    });
+});

--- a/test/Super1155.test.js
+++ b/test/Super1155.test.js
@@ -1,0 +1,1378 @@
+const { expect } = require('chai');
+const { BigNumber } = require('ethers');
+const { ethers } = require('hardhat');
+const Web3 = require('web3');
+
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const DATA = "0x02";
+
+///////////////////////////////////////////////////////////
+// SEE https://hardhat.org/tutorial/testing-contracts.html
+// FOR HELP WRITING TESTS
+// USE https://github.com/gnosis/mock-contract FOR HELP
+// WITH MOCK CONTRACT
+///////////////////////////////////////////////////////////
+
+// Start test block
+describe('===Super1155===', function () {
+    let deployer, owner, proxyRegistryOwner, signer1;
+    let setUriRight,
+        setProxyRegistryRight,
+        setConfigureGroupRight,
+        mintRight,
+        burnRight,
+        setMetadataRight,
+        lockUriRight,
+        lockItemUriRight,
+        lockCreationRight;
+    let UNIVERSAL;
+    let super1155;
+    let proxyRegistry;
+    let omdProxy;
+    const originalUri = "://ipfs/uri/{id}";
+    let itemGroupId = ethers.BigNumber.from(1);
+    let shiftedItemGroupId = itemGroupId.shl(128);
+    let itemGroupId2 = ethers.BigNumber.from(2);
+    let shiftedItemGroupId2 = itemGroupId2.shl(128);
+
+    // Keccak256 of "version()" in Super1155.sol
+    // Must return true when delegateCall is called from OwnableDelegateProxy
+    let selector = "0x54fd4d50fce680dbc2593d9e893064bfa880e5642d0036394e1a1849f7fc0749"
+
+    before(async function () {
+        this.Super1155 = await ethers.getContractFactory("Super1155");
+        this.ProxyRegistry = await ethers.getContractFactory("ProxyRegistry");
+        this.OMDProxy = await ethers.getContractFactory("OwnableMutableDelegateProxy");
+    });
+
+    beforeEach(async function () {
+        [deployer, owner, proxyRegistryOwner, signer1] = await ethers.getSigners();
+
+        proxyRegistry = await this.ProxyRegistry.deploy();
+        await proxyRegistry.deployed();
+        await proxyRegistry.transferOwnership(proxyRegistryOwner.address);
+
+        super1155 = await this.Super1155.deploy(
+            owner.address,
+            "Super1155",
+            originalUri,
+            proxyRegistry.address
+        );
+        await super1155.deployed();
+
+        omdProxy = await this.OMDProxy.deploy(owner.address, super1155.address, selector);
+        await omdProxy.deployed();
+
+        setUriRight = await super1155.SET_URI();
+        setProxyRegistryRight = await super1155.SET_PROXY_REGISTRY();
+        setConfigureGroupRight = await super1155.CONFIGURE_GROUP();
+        mintRight = await super1155.MINT();
+        burnRight = await super1155.BURN();
+        setMetadataRight = await super1155.SET_METADATA();
+        lockUriRight = await super1155.LOCK_URI();
+        lockItemUriRight = await super1155.LOCK_ITEM_URI();
+        lockCreationRight = await super1155.LOCK_CREATION();
+        UNIVERSAL = await super1155.UNIVERSAL();
+    });
+
+    // Test cases
+
+    //////////////////////////////
+    //       Constructor
+    //////////////////////////////
+    describe("Constructor", function () {
+        it('should initialize values as expected', async function () {
+            expect(await super1155.owner()).to.equal(owner.address);
+            expect(await super1155.name()).to.equal('Super1155');
+            expect(await super1155.metadataUri()).to.equal(originalUri);
+            expect(await super1155.proxyRegistryAddress()).to.equal(proxyRegistry.address);
+        });
+
+        it('should deploy a new instance where deployer is the owner', async function () {
+            super1155 = await this.Super1155.deploy(
+                deployer.address,
+                "Super1155",
+                originalUri,
+                proxyRegistry.address
+            );
+            await super1155.deployed();
+
+            expect(await super1155.owner()).to.equal(deployer.address);
+            expect(await super1155.name()).to.equal('Super1155');
+            expect(await super1155.metadataUri()).to.equal(originalUri);
+            expect(await super1155.proxyRegistryAddress()).to.equal(proxyRegistry.address);
+        });
+    });
+
+    describe("version", function () {
+        it('should return the correct version', async function(){
+            expect(await super1155.version()).to.equal(1)
+        });
+    });
+
+    describe("uri", function () {
+        it('should return the metadataUri', async function () {
+            expect(await super1155.uri(1)).to.equal(originalUri);
+        });
+    });
+
+    describe("setURI", function () {
+        it('Reverts: no valid permit', async function () {
+            await expect(
+                super1155.setURI("://ipfs/newuri/{id}")
+            ).to.be.revertedWith('PermitControl: sender does not have a valid permit');
+            expect(await super1155.uri(1)).to.equal(originalUri);
+        });
+
+        it('Reverts: collection has been locked', async function () {
+            await super1155.connect(owner)["lockURI(string)"]("hi");
+            await expect(
+                super1155.connect(owner).setURI("://ipfs/newuri/{id}")
+            ).to.be.revertedWith("Super1155: the collection URI has been permanently locked");
+
+            expect(await super1155.uri(1)).to.equal('hi');
+        });
+
+        it('should set the metadataUri when there is a valid permit', async function () {
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                setUriRight,
+                ethers.constants.MaxUint256
+            );
+            await super1155.setURI("://ipfs/newuri/{id}");
+            expect(await super1155.uri(1)).to.equal("://ipfs/newuri/{id}");
+            expect(await super1155.uriLocked()).to.equal(false);
+        });
+    });
+
+    describe("setProxyRegistry", function() {
+        it('Reverts: no valid permit', async function () {
+            await expect(
+                super1155.setProxyRegistry(proxyRegistry.address)
+            ).to.be.revertedWith('PermitControl: sender does not have a valid permit');
+        });
+
+        it('should set ProxyRegistry when there is permission', async function(){
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                setProxyRegistryRight,
+                ethers.constants.MaxUint256
+            )
+            await super1155.connect(deployer).setProxyRegistry(owner.address);
+            expect(await super1155.proxyRegistryAddress()).to.be.equal(owner.address);
+        });
+    })
+
+    describe("setApprovalForAll, isApprovedForAll", function () {
+        it('Reverts: setting approval status for self', async () => {
+            await expect(
+                super1155.connect(deployer).setApprovalForAll(deployer.address, true)
+            ).to.be.revertedWith("ERC1155: setting approval status for self");
+        });
+
+        it('uses operatorApprovals except when the operator is registered in the proxyRegistry', async () => {
+            expect(await super1155.isApprovedForAll(deployer.address, signer1.address)).to.equal(false);
+            await super1155.setApprovalForAll(signer1.address, true);
+            expect(await super1155.isApprovedForAll(deployer.address, signer1.address)).to.equal(true);
+            await super1155.setApprovalForAll(signer1.address, false);
+            expect(await super1155.isApprovedForAll(deployer.address, signer1.address)).to.equal(false);
+        });
+
+        it('returns true when proxyRegistry.proxies(_owner) == operator', async () => {
+            let MockProxyRegistry = await ethers.getContractFactory("MockProxyRegistry");
+            let mockProxyRegistry = await MockProxyRegistry.deploy();
+            await mockProxyRegistry.deployed();
+            await super1155.connect(owner).setProxyRegistry(mockProxyRegistry.address);
+
+            expect(await super1155.isApprovedForAll(deployer.address, signer1.address)).to.equal(false);
+            expect(await mockProxyRegistry.proxies(deployer.address)).to.equal(NULL_ADDRESS);
+
+            await mockProxyRegistry.connect(deployer).setProxy(deployer.address, signer1.address);
+            expect(await mockProxyRegistry.proxies(deployer.address)).to.equal(signer1.address);
+            expect(await super1155.isApprovedForAll(deployer.address, signer1.address)).to.equal(true);
+
+            await mockProxyRegistry.connect(deployer).setProxy(deployer.address, NULL_ADDRESS);
+            expect(await mockProxyRegistry.proxies(deployer.address)).to.equal(NULL_ADDRESS);
+            expect(await super1155.isApprovedForAll(deployer.address, signer1.address)).to.equal(false);
+        });
+    });
+
+    describe("safeTransferFrom, safeBatchTransferFrom", function () {
+        beforeEach(async function(){
+            // Create Itemsgroup ID = 1
+            await super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'PEPSI',
+                    supplyType: 0,
+                    supplyData: 10,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 1,
+                    burnData: 6
+                });
+            
+            // Create Itemsgroup ID = 2
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'COLA',
+                    supplyType: 0,
+                    supplyData: 15,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 2,
+                    burnData: 5
+                });
+
+            // Mint fungible item
+            await super1155.connect(owner).mintBatch(deployer.address, [shiftedItemGroupId], ["7"], DATA);
+            await super1155.connect(owner).mintBatch(deployer.address, [shiftedItemGroupId2], ["7"], DATA);
+        });
+
+        it('Reverts: transfer to Zero address', async () => {
+            await expect(
+                super1155.connect(signer1).safeTransferFrom(deployer.address, NULL_ADDRESS, shiftedItemGroupId.add(1), "5", DATA)
+            ).to.be.revertedWith("ERC1155: transfer to the zero address");
+
+        });
+
+        it('Reverts: transfer not approved', async () => {
+            await expect(
+                super1155.connect(signer1).safeTransferFrom(deployer.address, owner.address, shiftedItemGroupId.add(1), "5", DATA)
+            ).to.be.revertedWith("ERC1155: caller is not owner nor approved");
+        });
+
+        it('Reverts: transfer has insufficient balance', async () => {
+            // Approve the transfer
+            await super1155.connect(deployer).setApprovalForAll(signer1.address, true);
+
+            await expect(
+                super1155.connect(signer1).safeTransferFrom(deployer.address, owner.address, shiftedItemGroupId.add(1), "8", DATA)
+            ).to.be.revertedWith("ERC1155: insufficient balance for transfer");
+        });
+
+        it('Reverts: transferAcceptanceCheck on a contract with no ERC1155Receiver', async () => {
+            // Approve the transfer
+            await super1155.connect(deployer).setApprovalForAll(signer1.address, true);
+
+            // Try transfering to a contract with no ERC1155Receiver
+            await expect(
+                super1155.connect(signer1).safeTransferFrom(deployer.address, proxyRegistry.address, shiftedItemGroupId.add(1), "1", DATA)
+            ).to.be.revertedWith("ERC1155: transfer to non ERC1155Receiver implementer");
+        });
+
+        it('Reverts: transferAcceptanceCheck on a contract with ERC1155Receiver but response is not a selector', async () => {
+            // Approve the transfer
+            await super1155.connect(deployer).setApprovalForAll(signer1.address, true);
+
+            // Create a contract with IERC1155Receiver
+            let MockERC1155Receiver2 = await ethers.getContractFactory("MockERC1155Receiver2");
+            let mockERC1155Receiver2 = await MockERC1155Receiver2.deploy();
+            await mockERC1155Receiver2.deployed();
+
+            // Try transfering to a contract with reponse as a selector
+            await expect(
+                super1155.connect(signer1).safeTransferFrom(deployer.address, mockERC1155Receiver2.address, shiftedItemGroupId.add(1), "1", DATA)
+            ).to.be.revertedWith("ERC1155: ERC1155Receiver rejected tokens");
+        });
+
+        it('should do transferAcceptanceCheck on a contract with ERC1155Receiver and response is a selector', async () => {
+            // Approve the transfer
+            await super1155.connect(deployer).setApprovalForAll(signer1.address, true);
+
+            // Create a contract with IERC1155Receiver
+            let MockERC1155Receiver1 = await ethers.getContractFactory("MockERC1155Receiver1");
+            let mockERC1155Receiver1 = await MockERC1155Receiver1.deploy();
+            await mockERC1155Receiver1.deployed();
+
+            // Try transfering to a contract with reponse as a selector
+            await super1155.connect(signer1).safeTransferFrom(deployer.address, mockERC1155Receiver1.address, shiftedItemGroupId.add(1), "1", DATA);
+            await expect(
+                await super1155.connect(owner).balanceOf(mockERC1155Receiver1.address, shiftedItemGroupId.add(1))
+            ).to.be.equal("1");
+        });
+        
+        it('should transfer specified amount to specified address', async () => {
+            // Approve the transfer
+            await super1155.connect(deployer).setApprovalForAll(signer1.address, true);
+
+            await expect(
+                await super1155.connect(owner).balanceOf(owner.address, shiftedItemGroupId.add(1))
+            ).to.be.equal("0");
+
+            await super1155.connect(signer1).safeTransferFrom(deployer.address, owner.address, shiftedItemGroupId.add(1), "1", DATA)
+          
+            await expect(
+                await super1155.connect(owner).balanceOf(owner.address, shiftedItemGroupId.add(1))
+            ).to.be.equal("1");
+        });
+
+        it('Reverts: transferBatch ids and amounts length mismatch', async () => {
+            await expect(
+                super1155.connect(signer1).safeBatchTransferFrom(deployer.address, owner.address, [shiftedItemGroupId.add(1), shiftedItemGroupId2.add(1)], ["5", "5", "5"], DATA)
+            ).to.be.revertedWith("ERC1155: ids and amounts length mismatch");
+        });
+
+        it('Reverts: transferBatch to Zero address', async () => {
+            await expect(
+                super1155.connect(signer1).safeBatchTransferFrom(deployer.address, NULL_ADDRESS, [shiftedItemGroupId.add(1), shiftedItemGroupId2.add(1)], ["5", "5"], DATA)
+            ).to.be.revertedWith("ERC1155: transfer to the zero address");
+        });
+
+        it('Reverts: transferBatch not approved', async () => {
+            await expect(
+                super1155.connect(signer1).safeBatchTransferFrom(deployer.address, owner.address, [shiftedItemGroupId.add(1), shiftedItemGroupId2.add(1)], ["5", "5"], DATA)
+            ).to.be.revertedWith("ERC1155: caller is not owner nor approved");
+        });
+
+        it('Reverts: transferBatch has insufficient balance', async () => {
+            // Approve the transfer
+            await super1155.connect(deployer).setApprovalForAll(signer1.address, true);
+
+            await expect(
+                super1155.connect(signer1).safeBatchTransferFrom(deployer.address, owner.address, [shiftedItemGroupId.add(1), shiftedItemGroupId2.add(1)], ["8", "8"], DATA)
+            ).to.be.revertedWith("ERC1155: insufficient balance for transfer");
+        });
+
+        it('Reverts: batchTransferAcceptanceCheck on a contract with no ERC1155Receiver', async () => {
+            // Approve the transfer
+            await super1155.connect(deployer).setApprovalForAll(signer1.address, true);
+
+            // Try transfering to a contract with no ERC1155Receiver
+            await expect(
+                super1155.connect(signer1).safeBatchTransferFrom(deployer.address, proxyRegistry.address, [shiftedItemGroupId.add(1)], ["1"], DATA)
+            ).to.be.revertedWith("ERC1155: transfer to non ERC1155Receiver implementer");
+        });
+
+        it('Reverts: batchTransferAcceptanceCheck on a contract with ERC1155Receiver but response is not a selector', async () => {
+            // Approve the transfer
+            await super1155.connect(deployer).setApprovalForAll(signer1.address, true);
+
+            // Create a contract with IERC1155Receiver
+            let MockERC1155Receiver2 = await ethers.getContractFactory("MockERC1155Receiver2");
+            let mockERC1155Receiver2 = await MockERC1155Receiver2.deploy();
+            await mockERC1155Receiver2.deployed();
+
+            // Try transfering to a contract with reponse as a selector
+            await expect(
+                super1155.connect(signer1).safeBatchTransferFrom(deployer.address, mockERC1155Receiver2.address, [shiftedItemGroupId.add(1)], ["1"], DATA)
+            ).to.be.revertedWith("ERC1155: ERC1155Receiver rejected tokens");
+        });
+
+       it('should do batchTransferAcceptanceCheck on a contract with ERC1155Receiver and response is a selector', async () => {
+            // Approve the transfer
+            await super1155.connect(deployer).setApprovalForAll(signer1.address, true);
+
+            // Create a contract with IERC1155Receiver
+            let MockERC1155Receiver1 = await ethers.getContractFactory("MockERC1155Receiver1");
+            let mockERC1155Receiver1 = await MockERC1155Receiver1.deploy();
+            await mockERC1155Receiver1.deployed();
+
+            // Try transfering to a contract with reponse as a selector
+            await super1155.connect(signer1).safeBatchTransferFrom(deployer.address, mockERC1155Receiver1.address, [shiftedItemGroupId.add(1)], ["1"], DATA);
+            await expect(
+                await super1155.connect(owner).balanceOf(mockERC1155Receiver1.address, shiftedItemGroupId.add(1))
+            ).to.be.equal("1");
+        });
+        
+        it('should transferBatch specified amount to specified address', async () => {
+            // Approve the transfer
+            await super1155.connect(deployer).setApprovalForAll(signer1.address, true);
+
+            await expect(
+                await super1155.connect(owner).balanceOf(owner.address, shiftedItemGroupId.add(1))
+            ).to.be.equal("0");
+
+            await super1155.connect(signer1).safeBatchTransferFrom(deployer.address, owner.address, [shiftedItemGroupId.add(1), shiftedItemGroupId2.add(1)], ["1", "1"], DATA)
+          
+            await expect(
+                await super1155.connect(owner).balanceOf(owner.address, shiftedItemGroupId.add(1))
+            ).to.be.equal("1");
+        });
+    });
+
+    describe("configureGroup & balanceOf", function() {
+        it('Reverts: groupId is 0', async () => {
+            await expect(
+                super1155.connect(owner).configureGroup(0, {
+                    name: 'KFC',
+                    supplyType: 0,
+                    supplyData: 20000,
+                    itemType: 0,
+                    itemData: 0,
+                    burnType: 1,
+                    burnData: 20000
+                })
+            ).to.be.revertedWith("Super1155: group ID 0 is invalid");
+        });
+
+        it('Reverts: sender does not have the right', async () => {
+            super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFC',
+                supplyType: 0,
+                supplyData: 20000,
+                itemType: 0,
+                itemData: 0,
+                burnType: 1,
+                burnData: 20000
+            });
+            // Since the revert string from the modifier is missing in the .sol file, we compare to ""
+            await expect((await super1155.connect(owner).itemGroups(itemGroupId)).name).to.be.equal("");
+        });
+
+        it('Reverts: collection is locked', async function(){
+            await super1155.connect(owner).lock();
+
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                setConfigureGroupRight,
+                ethers.constants.MaxUint256
+            );
+
+            await expect(
+                super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFC',
+                supplyType: 0,
+                supplyData: 20000,
+                itemType: 0,
+                itemData: 0,
+                burnType: 1,
+                burnData: 20000
+            })).to.be.revertedWith('Super1155: the collection is locked so groups cannot be created');
+        });
+
+        it('should create a group with UNIVERSAL right', async () => {
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                setConfigureGroupRight,
+                ethers.constants.MaxUint256
+            );
+
+            await super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFC',
+                supplyType: 0,
+                supplyData: 20000,
+                itemType: 0,
+                itemData: 0,
+                burnType: 1,
+                burnData: 20000
+            });
+
+            await expect(
+                await (await super1155.connect(owner).itemGroups(itemGroupId)).name
+                ).to.be.equal("KFC");
+                
+        });
+
+        it('should create a group with GROUP right for specific GROUP circumstance', async () => {
+            // spicificGroup is the circumstance
+            let specificGroup = "0x0000000000000000000000000000000000000000000000000000000000000002";
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                specificGroup,
+                setConfigureGroupRight,
+                ethers.constants.MaxUint256
+            );
+
+            await super1155.connect(deployer).configureGroup(specificGroup, {
+                name: 'BURGERKING',
+                supplyType: 0,
+                supplyData: 20000,
+                itemType: 0,
+                itemData: 0,
+                burnType: 1,
+                burnData: 20000
+            });
+            
+            await expect(
+                await (await super1155.connect(owner).itemGroups(specificGroup)).name
+                ).to.be.equal("BURGERKING");
+        });
+
+        it('tests the editability of a group with multiple reverts handling', async () => {
+            // The test goes from Less Restrictive to More Restrictive supplyType, itemType and burnType
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                setConfigureGroupRight,
+                ethers.constants.MaxUint256
+            );
+
+            // Create base editable group
+            // Flexible, Fungible, Replenishable
+            await super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFC',
+                supplyType: 2,
+                supplyData: 20000,
+                itemType: 1,
+                itemData: 0,
+                burnType: 2,
+                burnData: 0
+            });
+
+            await expect(
+                await (await super1155.connect(owner).itemGroups(itemGroupId)).name
+                ).to.be.equal("KFC");
+            
+            // (From) Flexible, Fungible, Replenishable (To) Flexible, Fungible, Replenishable (Changes) name
+            super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv2',
+                supplyType: 2,
+                supplyData: 20000,
+                itemType: 1,
+                itemData: 0,
+                burnType: 2,
+                burnData: 8
+            });
+
+            await expect(
+                await (await super1155.connect(owner).itemGroups(itemGroupId)).name
+                ).to.be.equal("KFCv2");
+
+            // Mint some Fungible tokens to deployer, TokenID = 1
+            // Fungible items are coerced into the single group ID + index one slot.
+            await super1155.connect(owner).mintBatch(deployer.address, [shiftedItemGroupId], ["10"], DATA);
+            await expect(
+                await super1155.balanceOf(deployer.address, shiftedItemGroupId.add(1))
+                ).to.be.equal("10");
+
+            await expect(
+                super1155.connect(deployer).configureGroup(itemGroupId, {
+                    name: 'KFCv3',
+                    supplyType: 0,
+                    supplyData: 9,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 0,
+                    burnData: 0
+            })).to.be.revertedWith("Super1155: you may not decrease supply below the circulating amount");
+
+            // (From) Flexible, Fungible, Replenishable (To) Flexible, Fungible, Replenishable (Changes) supplyData
+            super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv3',
+                supplyType: 2,
+                supplyData: 15000,
+                itemType: 1,
+                itemData: 0,
+                burnType: 2,
+                burnData: 0
+            });
+
+            await expect(
+                await (await super1155.connect(owner).itemGroups(itemGroupId)).name
+                ).to.be.equal("KFCv3");
+
+            // (From) Flexible, Fungible, Replenishable (To) Uncapped, Fungible, Replenishable (Changes) supplyType
+            super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv4',
+                supplyType: 1,
+                supplyData: 15000,
+                itemType: 1,
+                itemData: 0,
+                burnType: 2,
+                burnData: 0
+            });
+
+            await expect(
+                await (await super1155.connect(owner).itemGroups(itemGroupId)).name
+                ).to.be.equal("KFCv4");
+
+            // (From) Uncapped, Fungible, Replenishable (To) Capped, Fungible, Replenishable (Changes) supplyType
+            super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv5',
+                supplyType: 0,
+                supplyData: 15000,
+                itemType: 1,
+                itemData: 0,
+                burnType: 2,
+                burnData: 0
+            });
+
+            await expect(
+                await (await super1155.connect(owner).itemGroups(itemGroupId)).name
+                ).to.be.equal("KFCv5");
+
+            // Can't edit uncap to cap again
+            await expect(super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv6',
+                supplyType: 1,
+                supplyData: 15000,
+                itemType: 1,
+                itemData: 0,
+                burnType: 2,
+                burnData: 0
+            })).to.be.revertedWith("Super1155: you may not uncap a capped supply type");
+
+            await expect(super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv6',
+                supplyType: 0,
+                supplyData: 20000,
+                itemType: 1,
+                itemData: 0,
+                burnType: 2,
+                burnData: 0
+            })).to.be.revertedWith("Super1155: you may not increase the supply of a capped type");
+
+            // (From) Capped, Fungible, Replenishable (To) Capped, Fungible, Burnable (Changes) burnType, burnData
+            super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv6',
+                supplyType: 0,
+                supplyData: 15000,
+                itemType: 1,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            });
+
+            await expect(
+                await (await super1155.connect(owner).itemGroups(itemGroupId)).name
+                ).to.be.equal("KFCv6");
+
+            // Burn some tokens
+            await super1155.connect(owner).burn(deployer.address, shiftedItemGroupId.add(1), "8");
+
+            await expect(
+                await super1155.balanceOf(deployer.address, shiftedItemGroupId.add(1))
+                ).to.be.equal("2");
+
+            // To be non-fungible, item must be unique
+            await expect(
+                super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv7',
+                supplyType: 0,
+                supplyData: 2,
+                itemType: 0,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            })).to.be.revertedWith("Super1155: the fungible item is not unique enough to change");
+
+            await expect(
+                super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv7',
+                supplyType: 0,
+                supplyData: 1,
+                itemType: 0,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            })).to.be.revertedWith("Super1155: you may not decrease supply below the circulating amount");
+
+            super1155.connect(owner).burn(deployer.address, shiftedItemGroupId, "1");
+
+            // (From) Capped, Fungible, Burnable (To) Capped, NonFungible, Burnable (Changes) itemType
+            super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv7',
+                supplyType: 0,
+                supplyData: 2,
+                itemType: 0,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            });
+
+            await expect(
+                await (await super1155.connect(owner).itemGroups(itemGroupId)).name
+                ).to.be.equal("KFCv7");
+
+            // Can't change a non-fungible to fungible again
+            await expect(super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'KFCv8',
+                supplyType: 0,
+                supplyData: 1,
+                itemType: 1,
+                itemData: 0,
+                burnType: 1,
+                burnData: 0
+            })).to.be.revertedWith("Super1155: you may not alter nonfungible items");
+
+            // Check for semi-fungible
+            // Create Capped, Fungible, Burnable (Changes) itemType
+            super1155.connect(deployer).configureGroup(itemGroupId2, {
+                name: 'MCDONALD',
+                supplyType: 0,
+                supplyData: 2,
+                itemType: 1,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            });
+
+            await expect(
+                await (await super1155.connect(owner).itemGroups(itemGroupId2)).name
+                ).to.be.equal("MCDONALD");
+
+            // Mint some tokens to deployer, TokenID = 0
+            await super1155.connect(owner).mintBatch(deployer.address, [shiftedItemGroupId2], ["2"], DATA);
+
+            await expect(
+                super1155.connect(deployer).configureGroup(itemGroupId2, {
+                name: 'MCDONALDv2',
+                supplyType: 0,
+                supplyData: 2,
+                itemType: 2,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            })).to.be.revertedWith("Super1155: the fungible item is not unique enough to change");
+
+            // Burn to make the fungible item unique
+            await super1155.connect(owner).burn(deployer.address, shiftedItemGroupId2, "1");
+
+            // Change from fungible to semi-fungible
+            await super1155.connect(deployer).configureGroup(itemGroupId2, {
+                name: 'MCDONALDv2',
+                supplyType: 0,
+                supplyData: 2,
+                itemType: 2,
+                itemData: 1,
+                burnType: 1,
+                burnData: 5
+            })
+
+            await expect(
+                await (await super1155.connect(owner).itemGroups(itemGroupId2)).name
+                ).to.be.equal("MCDONALDv2");
+
+            // Can't change semi-fungible item to fungible again
+            await expect(
+                super1155.connect(deployer).configureGroup(itemGroupId2, {
+                name: 'MCDONALDv3',
+                supplyType: 0,
+                supplyData: 2,
+                itemType: 1,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            })).to.be.revertedWith("Super1155: you may not alter nonfungible items");
+        });
+
+        it('should configure a new non-fungible group and edit it to another non-fungible group', async function () {
+            await super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'NONFUNGIBLE',
+                supplyType: 1,
+                supplyData: 1,
+                itemType: 0,
+                itemData: 0,
+                burnType: 0,
+                burnData: 0
+            });
+
+            await super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'NONFUNGIBLE',
+                supplyType: 1,
+                supplyData: 1,
+                itemType: 0,
+                itemData: 0,
+                burnType: 0,
+                burnData: 0
+            });
+         });
+
+         it('should configure a new semi-fungible group and edit it to another semi-fungible group', async function () {
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'SEMIFUNGIBLE',
+                supplyType: 0,
+                supplyData: 1,
+                itemType: 2,
+                itemData: 0,
+                burnType: 0,
+                burnData: 0
+            });
+
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'SEMIFUNGIBLEv2',
+                supplyType: 0,
+                supplyData: 1,
+                itemType: 2,
+                itemData: 0,
+                burnType: 0,
+                burnData: 0
+            });
+         });
+
+         it('should configure a new fungible group and edit it to a non existing type', async function () {
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'FUNGIBLE',
+                supplyType: 0,
+                supplyData: 1,
+                itemType: 1,
+                itemData: 0,
+                burnType: 0,
+                burnData: 0
+            });
+
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'FUNGIBLEv2',
+                supplyType: 0,
+                supplyData: 1,
+                itemType: 2,
+                itemData: 0,
+                burnType: 0,
+                burnData: 0
+            });
+         });
+
+        it('Reverts: balance of Zero address', async function () {
+            await expect(
+                super1155.balanceOf(NULL_ADDRESS, 0)
+                ).to.be.revertedWith("ERC1155: balance query for the zero address");
+         });
+
+        it('should get the correct balance of a token relating to an address', async function () {
+            await expect(await super1155.balanceOf(deployer.address, 0)).to.be.equal(0);
+         });
+    })
+
+    describe("balanceOfBatch", function () {
+        it('Reverts: ids and amounts length mismatch', async function () {
+            // Check if the minted balances are correct
+            await expect(
+                super1155.connect(owner).balanceOfBatch([deployer.address, deployer.address, deployer.address], [shiftedItemGroupId.add(1), shiftedItemGroupId2.add(1)])
+            ).to.be.revertedWith("ERC1155: accounts and ids length mismatch");
+
+        });
+       it('should return an array of balances mapped to addresses', async function () {
+            // Create Itemsgroup ID = 1
+            await super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'PEPSI',
+                    supplyType: 1,
+                    supplyData: 10,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 1,
+                    burnData: 5
+                });
+            
+            // Create Itemsgroup ID = 2
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'COLA',
+                    supplyType: 0,
+                    supplyData: 15,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 2,
+                    burnData: 5
+                });
+
+            // Mint items in batch
+            await super1155.connect(owner).mintBatch(deployer.address, [shiftedItemGroupId, shiftedItemGroupId2], ["5", "5"], DATA);
+
+            // Check if the minted balances are correct
+            let balances = await super1155.connect(owner).balanceOfBatch([deployer.address, deployer.address], [shiftedItemGroupId.add(1), shiftedItemGroupId2.add(1)]);
+            expect(balances[0]).to.be.equal("5");
+            expect(balances[1]).to.be.equal("5");
+        }); 
+    });
+
+    describe("mintBatch, mintChecker", function () {
+        beforeEach(async function(){
+             // Create Itemsgroup ID = 1
+             await super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'PEPSI',
+                    supplyType: 1,
+                    supplyData: 10,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 1,
+                    burnData: 5
+                });
+            
+            // Create Itemsgroup ID = 2
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'COLA',
+                    supplyType: 0,
+                    supplyData: 15,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 2,
+                    burnData: 5
+                });
+
+            // Create Itemsgroup Non Fungible ID = 3
+            await super1155.connect(owner).configureGroup(itemGroupId2.add(1), {
+                name: 'MIRANDA',
+                    supplyType: 1,
+                    supplyData: 1,
+                    itemType: 0,
+                    itemData: 1,
+                    burnType: 2,
+                    burnData: 0
+                });
+
+            // Create Itemsgroup Semi Fungible ID = 4
+            await super1155.connect(owner).configureGroup(itemGroupId2.add(2), {
+                name: 'SEVENUP',
+                    supplyType: 1,
+                    supplyData: 1,
+                    itemType: 2,
+                    itemData: 0,
+                    burnType: 2,
+                    burnData: 0
+                });
+        });
+
+        it('Reverts: mint to Zero address', async function () {
+            // Mint to zero address
+            await expect(
+                super1155.connect(deployer).mintBatch(NULL_ADDRESS, [shiftedItemGroupId, shiftedItemGroupId2], ["5", "5"], DATA)
+            ).to.be.revertedWith("ERC1155: mint to the zero address");
+        });
+
+        it('Reverts: ids and amounts length mismatch', async function () {
+            // Mint with ids and amounts mismatch
+            await expect(
+                super1155.connect(deployer).mintBatch(deployer.address, [shiftedItemGroupId, shiftedItemGroupId2], ["5", "5", "5"], DATA)
+            ).to.be.revertedWith("ERC1155: ids and amounts length mismatch");
+        });
+
+        it('Reverts: no valid permit', async function () {
+            // Mint without permit
+            await expect(
+                super1155.connect(deployer).mintBatch(deployer.address, [shiftedItemGroupId, shiftedItemGroupId2], ["5", "5"], DATA)
+            ).to.be.revertedWith("Super1155: you do not have the right to mint that item");
+        });
+
+        it('Reverts: mint to non-existent itemsgroup', async function () {
+            // Set Permit for minting
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                mintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // MintChecker to non-existent group ID = 5
+            let nonExistentGroup = shiftedItemGroupId.mul(5);
+            await expect(
+                super1155.connect(deployer).mintBatch(deployer.address, [nonExistentGroup, shiftedItemGroupId2], ["1", "1"], DATA)
+            ).to.be.revertedWith("Super1155: you cannot mint a non-existent item group");
+        });
+
+        it('Reverts: minting beyond cap', async function () {
+            // Set Permit for minting
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                mintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // MintChecker to a group beyond its cap
+            await expect(
+                super1155.connect(deployer).mintBatch(deployer.address, [shiftedItemGroupId, shiftedItemGroupId2], ["10", "16"], DATA)
+            ).to.be.revertedWith("Super1155: you cannot mint a group beyond its cap");
+        });
+
+        it('Reverts: minting more than one non-fungible item', async function () {
+            // Set Permit for minting
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                mintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // MintChecker to a non fungible group more than 1 amount
+            let group3Item = (shiftedItemGroupId.mul(3)).add(2); // GroupID = 3, ItemID = 2
+            await expect(
+                super1155.connect(deployer).mintBatch(deployer.address, [group3Item], ["2"], DATA)
+            ).to.be.revertedWith("Super1155: you cannot mint more than a single nonfungible item");
+        });
+
+        it('Reverts: minting more than alloted semi-fungible items', async function () {
+            // Set Permit for minting
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                mintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // MintChecker to a semi fungible group more than 1 amount
+            let group4Item = (shiftedItemGroupId.mul(4)).add(2); // GroupID = 3, ItemID = 2
+            await expect(
+                super1155.connect(deployer).mintBatch(deployer.address, [group4Item], ["2"], DATA)
+            ).to.be.revertedWith("Super1155: you cannot mint more than the alloted semifungible items");
+        });
+
+        it('should mint tokens in batch to an address', async function () {
+            // Set Permit for minting
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                mintRight,
+                ethers.constants.MaxUint256
+            );
+
+            // Mint fungible group. Fungible items are coerced into the single group ID + index one slot.
+            await super1155.connect(deployer).mintBatch(deployer.address, [shiftedItemGroupId], ["2"], DATA);
+
+            // Check if the fungible items are minted at index 1 of the group
+            await expect(
+                await (await super1155.connect(owner).balanceOf(deployer.address, shiftedItemGroupId.add(1).toString()))
+                ).to.be.equal("2");
+        });
+
+        it('should mint semi fungible tokens in batch to an address', async function () {
+            // Create Itemsgroup Semi Fungible
+            await super1155.connect(owner).configureGroup(itemGroupId2.add(3), {
+                name: 'SEVENUP',
+                    supplyType: 1,
+                    supplyData: 1,
+                    itemType: 2,
+                    itemData: 1,
+                    burnType: 2,
+                    burnData: 0
+                });
+
+            // Set Permit for minting
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                mintRight,
+                ethers.constants.MaxUint256
+            );
+
+            let shiftedItemGroupId5 = shiftedItemGroupId.mul(5);
+
+            // Mint semi fungible group.
+            await super1155.connect(deployer).mintBatch(deployer.address, [shiftedItemGroupId5], ["1"], DATA);
+
+            // Check if the fungible items are minted at index 1 of the group
+            await expect(
+                await (await super1155.connect(owner).balanceOf(deployer.address, shiftedItemGroupId5.toString()))
+                ).to.be.equal("1");
+        });
+    });
+
+    describe("burn, burnBatch, burnChecker", function () {
+        let shiftedItemGroupId3, shiftedItemGroupId4;
+        beforeEach(async function(){
+            // Create Itemsgroup ID = 1
+            await super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'PEPSI',
+                    supplyType: 0,
+                    supplyData: 10,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 1,
+                    burnData: 6
+                });
+            
+            // Create Itemsgroup ID = 2
+            await super1155.connect(owner).configureGroup(itemGroupId2, {
+                name: 'COLA',
+                    supplyType: 0,
+                    supplyData: 15,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 2,
+                    burnData: 5
+                });
+
+            // Create Itemsgroup ID = 3
+            await super1155.connect(owner).configureGroup(itemGroupId2.add(1), {
+                name: 'MIRANDA',
+                    supplyType: 0,
+                    supplyData: 10,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 1,
+                    burnData: 6
+                });
+            
+            // Create Itemsgroup ID = 4
+            await super1155.connect(owner).configureGroup(itemGroupId2.add(2), {
+                name: 'SEVENUP',
+                    supplyType: 0,
+                    supplyData: 15,
+                    itemType: 1,
+                    itemData: 0,
+                    burnType: 2,
+                    burnData: 5
+                });
+
+            // Create the leftShifted itemgroup ID
+            shiftedItemGroupId3 = shiftedItemGroupId.mul(3);
+            shiftedItemGroupId4 = shiftedItemGroupId.mul(4);
+
+            // Mint fungible item
+            await super1155.connect(owner).mintBatch(deployer.address, [shiftedItemGroupId], ["5"], DATA);
+            await super1155.connect(owner).mintBatch(deployer.address, [shiftedItemGroupId2], ["5"], DATA);
+            await super1155.connect(owner).mintBatch(deployer.address, [shiftedItemGroupId3], ["5"], DATA);
+            await super1155.connect(owner).mintBatch(deployer.address, [shiftedItemGroupId4], ["5"], DATA);
+        });
+
+        it('Reverts: burn has no valid permit', async function () {
+            // Burn without any permit
+            // Modifier's revert string is missing. So, expectation is the balanced unchanged
+            await super1155.connect(deployer).burn(deployer.address, shiftedItemGroupId.add(1), "5");
+            await expect(
+                await super1155.connect(owner).balanceOf(deployer.address, shiftedItemGroupId.add(1))
+            ).to.be.equal("5");
+  
+        });
+
+        it('Reverts: burn from Zero address', async function () {
+            // Burn from Zero address
+            await expect(
+                super1155.connect(owner).burn(NULL_ADDRESS, shiftedItemGroupId.add(1), "5")
+                ).to.be.revertedWith("ERC1155: burn from the zero address");
+        });
+
+        it('Reverts: burn from non-existent itemgroup', async function () {
+            // BurnChecker from non-existent group ID = 5
+            let nonExistentGroup = shiftedItemGroupId.mul(5);
+            await expect(
+                super1155.connect(owner).burn(deployer.address, nonExistentGroup, "10")
+                ).to.be.revertedWith("Super1155: you cannot burn a non-existent item group");
+        });
+
+        it('Reverts: burn limit exceeded on itemgroup', async function () {
+            // BurnChecker more than the burn limit
+            await expect(
+                super1155.connect(owner).burn(deployer.address, shiftedItemGroupId.add(1), "7")
+                ).to.be.revertedWith("Super1155: you may not exceed the burn limit on this item group");
+
+        });
+
+        it('Reverts: burn amount is more than the holder balance', async function () {
+            // Burn more than the balance of holder
+            await expect(
+                super1155.connect(owner).burn(deployer.address, shiftedItemGroupId.add(1), "6")
+                ).to.be.revertedWith("ERC1155: burn amount exceeds balance");
+        });
+
+        it('should burn tokens individually based on UNIVERSAL, GROUP and ITEM circumstances (Modifier)', async function () {
+            // Burn 1 amount successfully 
+            super1155.connect(owner).burn(deployer.address, shiftedItemGroupId.add(1), "1");
+            await expect(
+                await super1155.connect(owner).balanceOf(deployer.address, shiftedItemGroupId.add(1))
+            ).to.be.equal("4");
+
+            // Set Permit for burning based on group circumstance
+            let groupCirumstance = "0x0000000000000000000000000000000000000000000000000000000000000001"
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                groupCirumstance,
+                burnRight,
+                ethers.constants.MaxUint256
+            );
+          
+            await super1155.connect(deployer).burn(deployer.address, shiftedItemGroupId, "1");
+            let balance = await super1155.connect(owner).balanceOf(deployer.address, shiftedItemGroupId.add(1));
+            expect(balance).to.be.equal("3");
+
+            // Set Permit for burning based on item circumstance
+            let itemCirumstance = "0x0000000000000000000000000000000100000000000000000000000000000001"
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                itemCirumstance,
+                burnRight,
+                ethers.constants.MaxUint256
+            );
+
+            await super1155.connect(deployer).burn(deployer.address, shiftedItemGroupId, "1");
+            balance = await super1155.connect(owner).balanceOf(deployer.address, shiftedItemGroupId.add(1));
+            expect(balance).to.be.equal("2");
+        });
+
+        it('should burn a non fungible token individually', async function () {
+        // Edit Itemsgroup ID = 4
+        await super1155.connect(owner).configureGroup(itemGroupId2.add(3), {
+            name: 'MONSTER',
+                supplyType: 1,
+                supplyData: 1,
+                itemType: 0,
+                itemData: 0,
+                burnType: 1,
+                burnData: 1
+            });
+
+            let shiftedItemGroupId5 = shiftedItemGroupId.mul(5);
+
+            // Mint 1 non fungible item
+            await super1155.connect(owner).mintBatch(deployer.address, [shiftedItemGroupId5], ["1"], DATA);
+
+            // Burn 1 amount successfully to make it eligible to be Non Fungible
+            await super1155.connect(owner).burn(deployer.address, shiftedItemGroupId5, "1");
+        });
+
+        it('Reverts: burnBatch from Zero address', async function () {
+            // BurnBatch from Zero address
+            await expect(
+                super1155.connect(owner).burnBatch(NULL_ADDRESS, [shiftedItemGroupId3, shiftedItemGroupId4], ["5", "5"])
+                ).to.be.revertedWith("ERC1155: burn from the zero address");
+        });
+
+        it('Reverts: burnBatch ids and amounts length mismatch', async function () {
+            // BurnBatch with id and amount length mismatch
+            await expect(
+                super1155.connect(owner).burnBatch(deployer.address, [shiftedItemGroupId3, shiftedItemGroupId4], ["5", "5", "5"])
+                ).to.be.revertedWith("ERC1155: ids and amounts length mismatch");
+        });
+
+        it('Reverts: burnBatch has no valid permit', async function () {
+            // BurnBatch without permission
+            await expect(
+                super1155.connect(deployer).burnBatch(deployer.address, [shiftedItemGroupId3, shiftedItemGroupId4], ["5", "5"])
+                ).to.be.revertedWith("Super1155: you do not have the right to burn that item");
+        });
+
+        it('Reverts: burnBatch from non-existent itemgroups', async function () {
+            // BurnChecker from non-existent group ID = 5
+            let nonExistentGroup = shiftedItemGroupId.mul(5);
+            await expect(
+                super1155.connect(owner).burnBatch(deployer.address, [nonExistentGroup, shiftedItemGroupId4], ["5", "5"])
+                ).to.be.revertedWith("Super1155: you cannot burn a non-existent item group");
+        });
+
+        it('Reverts: burnBatch limit exceeded the itemgroup burn limit', async function () {
+            // BurnChecker more than the burn limit
+            await expect(
+                super1155.connect(owner).burnBatch(deployer.address, [shiftedItemGroupId3, shiftedItemGroupId4], ["7", "6"])
+                ).to.be.revertedWith("Super1155: you may not exceed the burn limit on this item group");
+        });
+
+        it('Reverts: burnBatch amount is more than holder balance', async function () {
+            // Burn more than the balances of holders
+            await expect(
+                super1155.connect(owner).burnBatch(deployer.address, [shiftedItemGroupId3, shiftedItemGroupId4], ["6", "5"])
+                ).to.be.revertedWith("ERC1155: burn amount exceeds balance");
+        });
+
+        it('should burnBatch tokens in batch based on UNIVERSAL, GROUP and ITEM circumstances (Function)', async function () {
+            // Burn 1 amount from each address successfully 
+            await super1155.connect(owner).burnBatch(deployer.address, [shiftedItemGroupId3, shiftedItemGroupId4], ["1", "1"]);
+            let balancesBatch = await super1155.connect(owner).balanceOfBatch([deployer.address, deployer.address], [shiftedItemGroupId3.add(1), shiftedItemGroupId4.add(1)]);
+            expect(balancesBatch[0]).to.be.equal("4");
+            expect(balancesBatch[1]).to.be.equal("4");
+
+            // Set Permit for burning based on group circumstance
+            let groupCirumstance = "0x0000000000000000000000000000000000000000000000000000000000000003"
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                groupCirumstance,
+                burnRight,
+                ethers.constants.MaxUint256
+            );
+          
+            await super1155.connect(deployer).burnBatch(deployer.address, [shiftedItemGroupId3], ["1"]);
+            balancesBatch = await super1155.connect(owner).balanceOfBatch([deployer.address, deployer.address], [shiftedItemGroupId3.add(1), shiftedItemGroupId4.add(1)]);
+            expect(balancesBatch[0]).to.be.equal("3");
+            expect(balancesBatch[1]).to.be.equal("4");
+
+            // Set Permit for burning based on item circumstance
+            let itemCirumstance = "0x0000000000000000000000000000000400000000000000000000000000000001"
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                itemCirumstance,
+                burnRight,
+                ethers.constants.MaxUint256
+            );
+
+            await super1155.connect(deployer).burnBatch(deployer.address, [shiftedItemGroupId4.add(1)], ["1"]);
+            balancesBatch = await super1155.connect(owner).balanceOfBatch([deployer.address, deployer.address], [shiftedItemGroupId3.add(1), shiftedItemGroupId4.add(1)]);
+            expect(balancesBatch[0]).to.be.equal("3");
+            expect(balancesBatch[1]).to.be.equal("3");
+        });
+    });
+
+    describe("setMetadata", function () {
+        it('should set the metadata', async function () {
+            // Set permit for configuring group
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                setConfigureGroupRight,
+                ethers.constants.MaxUint256
+            );
+            
+            // Set permit for setting metadata
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                setMetadataRight,
+                ethers.constants.MaxUint256
+            );
+
+            // Set permit for locking an item
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                lockItemUriRight,
+                ethers.constants.MaxUint256
+            );
+  
+            // Create an ItemsGroup
+            await super1155.connect(deployer).configureGroup(itemGroupId, {
+                name: 'YOKITOKI',
+                supplyType: 1,
+                supplyData: 20000,
+                itemType: 1,
+                itemData: 0,
+                burnType: 1,
+                burnData: 2000
+            });
+
+            // Check if group has been created
+            await expect(
+                await (await super1155.connect(deployer).itemGroups(itemGroupId)).name
+                ).to.be.equal("YOKITOKI");
+
+            // Set metadata
+            await super1155.connect(deployer).setMetadata(shiftedItemGroupId, DATA);
+
+            // LockURI using overloaded method
+            await super1155.connect(deployer)["lockURI(string,uint256)"](DATA, shiftedItemGroupId);
+
+            // Check if metadata can be set again
+            await expect(
+                super1155.connect(deployer).setMetadata(shiftedItemGroupId, DATA)
+                ).to.be.revertedWith("Super1155: you cannot edit this metadata because it is frozen");            
+        });
+    });
+
+    describe("lockURI", function () {
+        it('Reverts: no valid permit', async function () {
+            await expect(
+                super1155["lockURI(string)"]("://ipfs/lockeduri/{id}")
+            ).to.be.revertedWith('PermitControl: sender does not have a valid permit');
+            expect(await super1155.uri(1)).to.equal(originalUri);
+        });
+
+        it('should set the metadataUri and lock it when there is a valid permit', async function () {
+            // Set permit for locking
+            await super1155.connect(owner).setPermit(
+                deployer.address,
+                UNIVERSAL,
+                lockUriRight,
+                ethers.constants.MaxUint256
+            );
+            await super1155["lockURI(string)"]("://ipfs/lockeduri/{id}")
+            expect(await super1155.uri(1)).to.equal("://ipfs/lockeduri/{id}");
+            expect(await super1155.uriLocked()).to.equal(true);
+        });
+    });
+
+    describe("lock", function () {
+        it('should lock the contract', async function () {
+            // Lock the Contract
+            await super1155.connect(owner).lock();
+
+            // Check if group can be created
+            await expect(super1155.connect(owner).configureGroup(itemGroupId, {
+                name: 'SUBWAY',
+                supplyType: 0,
+                supplyData: 2,
+                itemType: 1,
+                itemData: 0,
+                burnType: 1,
+                burnData: 5
+            })).to.be.revertedWith("Super1155: the collection is locked so groups cannot be created");
+        });
+    });
+});


### PR DESCRIPTION
=====Tests Written for Contracts
- Staker.sol
- Super1155.sol
- MintShop1155.sol
- Notary.sol
- PermitControl.sol
- Sweepable.sol

=====Mockfiles included for Tests
- MockERC20.sol
- MockERC1155Receivers.sol

=====Base contracts modified
Staker.sol
- setEmissions()

MintShop1155.sol
- getWhitelistStatus()
- getPurchaseCounts()

Sweepable.sol
- sweep()

=====Some improvements to consider
- Adding a revert string to the modifier (Super1155.sol)

=====Statements that could not be covered
Super1155.sol
- _doSafeBatchTransferAcceptanceCheck() => catch(Error): Unable to produce the Error for testing
- _doSafeTransferAcceptanceCheck() => catch(Error): Unable to produce the Error for testing
- line 711 => itemGroups[_groupId].itemType == ItemType.Fungible: Enum type check is done when creating the group. Invalid Enum value assignment throws an exception so the else part is never run.

MintShop1155.sol
- line 1043 => else part of this require => "MintShop1155: payment receiver transfer failed": Unable to produce the Error for testing
- line 1047 => sellingPair.assetType == AssetType.Token: Enum type check is done at the time of assigning value to it. Invalid Enum value assignment throws an exception so the else part's revert("MintShop1155: unrecognized asset type") is never run.

PermitControl.sol
- version(): Overridden

Sweepable.sol
- version(): Overridden

=====HardhatCoverage
- Make sure to do "npx hardhat clean" before running "npx hardhat coverage"