### PR TITLE
PermitControl changes

### DIFF
--- a/contracts/Super721.sol
+++ b/contracts/Super721.sol
@@ -326,11 +326,11 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     uint256 groupId = (_id & GROUP_MASK) >> 128;
     if (_msgSender() == owner()) {
       _;
-    } else if (hasRightUntil(_msgSender(), UNIVERSAL, _right)) {
+    } else if (hasRight(_msgSender(), UNIVERSAL, _right)) {
       _;
-    } else if (hasRightUntil(_msgSender(), bytes32(groupId), _right)) {
+    } else if (hasRight(_msgSender(), bytes32(groupId), _right)) {
       _;
-    } else if (hasRightUntil(_msgSender(), bytes32(_id), _right)) {
+    } else if (hasRight(_msgSender(), bytes32(_id), _right)) {
       _;
     } else {
       revert("Super721::hasItemRight: _msgSender does not have the right to perform that action");
@@ -745,13 +745,13 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     if (_msgSender() == owner()) {
       return true;
     }
-    if (hasRightUntil(_msgSender(), UNIVERSAL, _right)) {
+    if (hasRight(_msgSender(), UNIVERSAL, _right)) {
       return true;
     }
-    if (hasRightUntil(_msgSender(), bytes32(groupId), _right)) {
+    if (hasRight(_msgSender(), bytes32(groupId), _right)) {
       return true;
     }
-    if (hasRightUntil(_msgSender(), bytes32(_id), _right)) {
+    if (hasRight(_msgSender(), bytes32(_id), _right)) {
       return true;
     }
       return false;

--- a/contracts/Super721.sol
+++ b/contracts/Super721.sol
@@ -326,14 +326,11 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     uint256 groupId = (_id & GROUP_MASK) >> 128;
     if (_msgSender() == owner()) {
       _;
-    } else if (hasRightUntil(_msgSender(), UNIVERSAL, _right)
-      > block.timestamp) {
+    } else if (hasRightUntil(_msgSender(), UNIVERSAL, _right)) {
       _;
-    } else if (hasRightUntil(_msgSender(), bytes32(groupId), _right)
-      > block.timestamp) {
+    } else if (hasRightUntil(_msgSender(), bytes32(groupId), _right)) {
       _;
-    } else if (hasRightUntil(_msgSender(), bytes32(_id), _right)
-      > block.timestamp) {
+    } else if (hasRightUntil(_msgSender(), bytes32(_id), _right)) {
       _;
     } else {
       revert("Super721::hasItemRight: _msgSender does not have the right to perform that action");
@@ -747,18 +744,17 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     uint256 groupId = (_id & GROUP_MASK) >> 128;
     if (_msgSender() == owner()) {
       return true;
-    } else if (hasRightUntil(_msgSender(), UNIVERSAL, _right)
-      > block.timestamp) {
-      return true;
-    } else if (hasRightUntil(_msgSender(), bytes32(groupId), _right)
-      > block.timestamp) {
-      return true;
-    } else if (hasRightUntil(_msgSender(), bytes32(_id), _right)
-      > block.timestamp) {
-      return true;
-    } else {
-      return false;
     }
+    if (hasRightUntil(_msgSender(), UNIVERSAL, _right)) {
+      return true;
+    }
+    if (hasRightUntil(_msgSender(), bytes32(groupId), _right)) {
+      return true;
+    }
+    if (hasRightUntil(_msgSender(), bytes32(_id), _right)) {
+      return true;
+    }
+      return false;
   }
 
   /**

--- a/contracts/Super721IMX.sol
+++ b/contracts/Super721IMX.sol
@@ -329,14 +329,11 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     uint256 groupId = (_id & GROUP_MASK) >> 128;
     if (_msgSender() == owner()) {
       _;
-    } else if (hasRightUntil(_msgSender(), UNIVERSAL, _right)
-      > block.timestamp) {
+    } else if (hasRightUntil(_msgSender(), UNIVERSAL, _right)) {
       _;
-    } else if (hasRightUntil(_msgSender(), bytes32(groupId), _right)
-      > block.timestamp) {
+    } else if (hasRightUntil(_msgSender(), bytes32(groupId), _right)) {
       _;
-    } else if (hasRightUntil(_msgSender(), bytes32(_id), _right)
-      > block.timestamp) {
+    } else if (hasRightUntil(_msgSender(), bytes32(_id), _right)) {
       _;
     } else {
       revert("Super721::hasItemRight: _msgSender does not have the right to perform that action");
@@ -752,14 +749,11 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     uint256 groupId = (_id & GROUP_MASK) >> 128;
     if (_msgSender() == owner()) {
       return true;
-    } else if (hasRightUntil(_msgSender(), UNIVERSAL, _right)
-      > block.timestamp) {
+    } else if (hasRightUntil(_msgSender(), UNIVERSAL, _right)) {
       return true;
-    } else if (hasRightUntil(_msgSender(), bytes32(groupId), _right)
-      > block.timestamp) {
+    } else if (hasRightUntil(_msgSender(), bytes32(groupId), _right)) {
       return true;
-    } else if (hasRightUntil(_msgSender(), bytes32(_id), _right)
-      > block.timestamp) {
+    } else if (hasRightUntil(_msgSender(), bytes32(_id), _right)) {
       return true;
     } else {
       return false;

--- a/contracts/Super721IMX.sol
+++ b/contracts/Super721IMX.sol
@@ -329,11 +329,11 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     uint256 groupId = (_id & GROUP_MASK) >> 128;
     if (_msgSender() == owner()) {
       _;
-    } else if (hasRightUntil(_msgSender(), UNIVERSAL, _right)) {
+    } else if (hasRight(_msgSender(), UNIVERSAL, _right)) {
       _;
-    } else if (hasRightUntil(_msgSender(), bytes32(groupId), _right)) {
+    } else if (hasRight(_msgSender(), bytes32(groupId), _right)) {
       _;
-    } else if (hasRightUntil(_msgSender(), bytes32(_id), _right)) {
+    } else if (hasRight(_msgSender(), bytes32(_id), _right)) {
       _;
     } else {
       revert("Super721::hasItemRight: _msgSender does not have the right to perform that action");
@@ -749,11 +749,11 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     uint256 groupId = (_id & GROUP_MASK) >> 128;
     if (_msgSender() == owner()) {
       return true;
-    } else if (hasRightUntil(_msgSender(), UNIVERSAL, _right)) {
+    } else if (hasRight(_msgSender(), UNIVERSAL, _right)) {
       return true;
-    } else if (hasRightUntil(_msgSender(), bytes32(groupId), _right)) {
+    } else if (hasRight(_msgSender(), bytes32(groupId), _right)) {
       return true;
-    } else if (hasRightUntil(_msgSender(), bytes32(_id), _right)) {
+    } else if (hasRight(_msgSender(), bytes32(_id), _right)) {
       return true;
     } else {
       return false;

--- a/contracts/access/PermitControl.sol
+++ b/contracts/access/PermitControl.sol
@@ -105,7 +105,7 @@ abstract contract PermitControl is Ownable {
     bytes32 _right
   ) {
     require(_msgSender() == owner()
-      || hasRightUntil(_msgSender(), _circumstance, _right),
+      || hasRight(_msgSender(), _circumstance, _right),
       "PermitControl: sender does not have a valid permit");
     _;
   }
@@ -128,6 +128,23 @@ abstract contract PermitControl is Ownable {
       is zero, we can assume that the user never had the right.
   */
   function hasRightUntil(
+    address _address,
+    bytes32 _circumstance,
+    bytes32 _right
+  ) public view returns (uint256) {
+    return permissions[_address][_circumstance][_right];
+  }
+
+   /**
+    Determine whether or not an address has some rights under the given
+    circumstance,
+
+    @param _address The address to check for the specified `_right`.
+    @param _circumstance The circumstance to check the specified `_right` for.
+    @param _right The right to check for validity.
+    @return true or false, whether user has rights and time is valid.
+  */
+  function hasRight(
     address _address,
     bytes32 _circumstance,
     bytes32 _right

--- a/contracts/access/PermitControl.sol
+++ b/contracts/access/PermitControl.sol
@@ -105,7 +105,7 @@ abstract contract PermitControl is Ownable {
     bytes32 _right
   ) {
     require(_msgSender() == owner()
-      || hasRightUntil(_msgSender(), _circumstance, _right) > block.timestamp,
+      || hasRightUntil(_msgSender(), _circumstance, _right),
       "PermitControl: sender does not have a valid permit");
     _;
   }
@@ -131,8 +131,8 @@ abstract contract PermitControl is Ownable {
     address _address,
     bytes32 _circumstance,
     bytes32 _right
-  ) public view returns (uint256) {
-    return permissions[_address][_circumstance][_right];
+  ) public view returns (bool) {
+    return permissions[_address][_circumstance][_right] > block.timestamp;
   }
 
   /**

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -21,6 +21,8 @@ require('solidity-coverage');
 // Include the Etherscan contract verifier.
 require('@nomiclabs/hardhat-etherscan');
 
+require('hardhat-contract-sizer');
+
 // Retrieve sensitive node and private key details from environment variables.
 const INFURA_PROJECT_ID = process.env.INFURA_PROJECT_ID;
 const DEPLOYER_PRIVATE_KEY = process.env.DEPLOYER_PRIVATE_KEY;
@@ -102,5 +104,10 @@ module.exports = {
 	},
 	mocha: {
 		grep: '^(?!.*; using Ganache).*'
-	}
+	},
+    contractSizer: {
+        alphaSort: true,
+        runOnCompile: true,
+        disambiguatePaths: false,
+    }
 };

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -21,8 +21,6 @@ require('solidity-coverage');
 // Include the Etherscan contract verifier.
 require('@nomiclabs/hardhat-etherscan');
 
-require('hardhat-contract-sizer');
-
 // Retrieve sensitive node and private key details from environment variables.
 const INFURA_PROJECT_ID = process.env.INFURA_PROJECT_ID;
 const DEPLOYER_PRIVATE_KEY = process.env.DEPLOYER_PRIVATE_KEY;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ethereum-waffle": "^3.1.1",
     "ethers": "^5.0.25",
     "hardhat": "^2.6.4",
-    "hardhat-contract-sizer": "^2.0.2",
+    "hardhat-contract-sizer": "^2.1.1",
     "hardhat-gas-reporter": "^1.0.4",
     "husky": "^4.3.0",
     "npm-run-all": "^4.1.5",

--- a/test/Super1155.test.js
+++ b/test/Super1155.test.js
@@ -407,17 +407,17 @@ describe('===Super1155===', function () {
         });
 
         it('Reverts: sender does not have the right', async () => {
-            super1155.connect(deployer).configureGroup(itemGroupId, {
-                name: 'KFC',
-                supplyType: 0,
-                supplyData: 20000,
-                itemType: 0,
-                itemData: 0,
-                burnType: 1,
-                burnData: 20000
-            });
-            // Since the revert string from the modifier is missing in the .sol file, we compare to ""
-            await expect((await super1155.connect(owner).itemGroups(itemGroupId)).name).to.be.equal("");
+            await expect(
+                super1155.connect(deployer).configureGroup(itemGroupId, {
+                    name: 'KFC',
+                    supplyType: 0,
+                    supplyData: 20000,
+                    itemType: 0,
+                    itemData: 0,
+                    burnType: 1,
+                    burnData: 20000
+                })
+            ).to.be.revertedWith("Super1155: you don't have rights to configure group");
         });
 
         it('Reverts: collection is locked', async function(){
@@ -1107,13 +1107,9 @@ describe('===Super1155===', function () {
         });
 
         it('Reverts: burn has no valid permit', async function () {
-            // Burn without any permit
-            // Modifier's revert string is missing. So, expectation is the balanced unchanged
-            await super1155.connect(deployer).burn(deployer.address, shiftedItemGroupId.add(1), "5");
             await expect(
-                await super1155.connect(owner).balanceOf(deployer.address, shiftedItemGroupId.add(1))
-            ).to.be.equal("5");
-  
+                super1155.connect(deployer).burn(deployer.address, shiftedItemGroupId.add(1), "5")
+            ).to.be.revertedWith("Super1155: you don't have rights to burn");
         });
 
         it('Reverts: burn from Zero address', async function () {


### PR DESCRIPTION
-  **PermitControl**: hasRightUntil function now returns bool, it check if time for the right is greater than block.timestamp 
-  **Super1155**: changed functions which were using hasRightUntil function from PermitControl. Commented modifier hasItemRight, using _hasItemRight function instead. Reordered structs, which saved 2 memory slots in storage. Removed redundant usages of GROUP_MASK. Changed _hasTimeRight function in order to reduce produced bytecode. Commented single burn function and single safeTransherFrom.
-  **Super1155.test.js**: Changed according to changes of Super1155.sol.
-  **Super721IMX** & **Super721**: changed requires according to new version of hasRightUntil function.
-  Overall freed up 4KB of contracts size.