### PR TITLE
return metadata for tokenId

### DIFF
--- a/contracts/Super1155.sol
+++ b/contracts/Super1155.sol
@@ -367,7 +367,7 @@ contract Super1155 is PermitControl, ERC165Storage, IERC1155, IERC1155MetadataUR
     @return The metadata URI string of the item with ID `_itemId`.
   */
   function uri(uint256 id) external override view returns (string memory) {
-   Strings.Slice memory slice1 = metadataUri.toSlice();
+    Strings.Slice memory slice1 = metadataUri.toSlice();
     Strings.Slice memory slice2 = metadataUri.toSlice();
     string memory tokenFirst = "{";
     string memory tokenLast = "}";
@@ -948,12 +948,8 @@ contract Super1155 is PermitControl, ERC165Storage, IERC1155, IERC1155MetadataUR
   */
   function setMetadata(uint256 _id, string memory _metadata) external {
     require(_hasItemRight(_id, SET_METADATA), "Super1155: you don't have rights to setMetadata");
-<<<<<<< HEAD
     uint groupId = _id >> 128;
     require(!uriLocked && !metadataFrozen[_id] &&  !metadataFrozen[groupId],
-=======
-    require(!uriLocked && !metadataFrozen[_id],
->>>>>>> master
       "Super1155: you cannot edit this metadata because it is frozen");
     string memory oldMetadata = metadata[_id];
     metadata[_id] = _metadata;
@@ -995,8 +991,8 @@ contract Super1155 is PermitControl, ERC165Storage, IERC1155, IERC1155MetadataUR
     @param _uri The value of the URI to lock for `groupId`.
     @param groupId The group ID to lock a metadata URI value into.
   */
-  function lockGroupURI(string calldata _uri, uint256 groupId) external
-    hasItemRight(groupId, LOCK_ITEM_URI) {
+  function lockGroupURI(string calldata _uri, uint256 groupId) external {
+    require(_hasItemRight(groupId, LOCK_ITEM_URI), "Super1155: you don't have rights to lock group URI");
     metadataFrozen[groupId] = true;
     emit PermanentURI(_uri, groupId);
   }

--- a/contracts/Super1155.sol
+++ b/contracts/Super1155.sol
@@ -1052,8 +1052,8 @@ contract Super1155 is PermitControl, ERC165Storage, IERC1155, IERC1155MetadataUR
     @param _id The ID of the token to set the `_metadata` for.
     @param _metadata The metadata string to store on-chain.
   */
-  function setMetadata(uint256 _id, string memory _metadata)
-    external hasItemRight(_id, SET_METADATA) {
+  function setMetadata(uint256 _id, string memory _metadata) external {
+    require(_hasItemRight(_id, SET_METADATA), "Super1155: you don't have rights to setMetadata");
     uint groupId = _id >> 128;
     require(!uriLocked && !metadataFrozen[_id] &&  !metadataFrozen[groupId],
       "Super1155: you cannot edit this metadata because it is frozen");

--- a/contracts/Super1155.sol
+++ b/contracts/Super1155.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
 
 import "./access/PermitControl.sol";
 import "./proxy/StubProxyRegistry.sol";
+import "./utils/LocalStrings.sol";
 
 /**
   @title An ERC-1155 item creation contract.
@@ -27,6 +28,7 @@ import "./proxy/StubProxyRegistry.sol";
 */
 contract Super1155 is PermitControl, ERC165Storage, IERC1155, IERC1155MetadataURI {
   using Address for address;
+  using Strings for string;
 
   /// The public identifier for the right to set this contract's metadata URI.
   bytes32 public constant SET_URI = keccak256("SET_URI");
@@ -216,23 +218,6 @@ contract Super1155 is PermitControl, ERC165Storage, IERC1155, IERC1155MetadataUR
   /// A mapping of the number of times each individual token has been burnt.
   mapping (uint256 => uint256) public burnCount;
 
-  /**
-    A mapping of token ID to a boolean representing whether the item's metadata
-    has been explicitly frozen via a call to `lockURI(string calldata _uri,
-    uint256 _id)`. Do note that it is possible for an item's mapping here to be
-    false while still having frozen metadata if the item collection as a whole
-    has had its `uriLocked` value set to true.
-  */
-  mapping (uint256 => bool) public metadataFrozen;
-
-  /**
-    A public mapping of optional on-chain metadata for each token ID. A token's
-    on-chain metadata is unable to be changed if the item's metadata URI has
-    been permanently fixed or if the collection's metadata URI as a whole has
-    been frozen.
-  */
-  mapping (uint256 => string) public metadata;
-
   /// Whether or not the metadata URI has been locked to future changes.
   bool public uriLocked;
 
@@ -273,18 +258,6 @@ contract Super1155 is PermitControl, ERC165Storage, IERC1155, IERC1155MetadataUR
     @param locker The caller who locked the collection.
   */
   event CollectionLocked(address indexed locker);
-
-  /**
-    An event that gets emitted when a token ID has its on-chain metadata
-    changed.
-
-    @param changer The caller who triggered the metadata change.
-    @param id The ID of the token which had its metadata changed.
-    @param oldMetadata The old metadata of the token.
-    @param newMetadata The new metadata of the token.
-  */
-  event MetadataChanged(address indexed changer, uint256 indexed id,
-    string oldMetadata, string indexed newMetadata);
 
   /**
     An event that indicates we have set a permanent metadata URI for a token.
@@ -365,8 +338,19 @@ contract Super1155 is PermitControl, ERC165Storage, IERC1155, IERC1155MetadataUR
 
     @return The metadata URI string of the item with ID `_itemId`.
   */
-  function uri(uint256) external override view returns (string memory) {
-    return metadataUri;
+  function uri(uint256 id) public override view returns (string memory) {
+    Strings.Slice memory slice1 = metadataUri.toSlice();
+    Strings.Slice memory slice2 = metadataUri.toSlice();
+    string memory tokenFirst = "{";
+    string memory tokenLast = "}";
+    Strings.Slice memory firstSlice = tokenFirst.toSlice();
+    Strings.Slice memory secondSlice = tokenLast.toSlice();
+    firstSlice = Strings.beforeMatch(slice1, firstSlice);
+    secondSlice = Strings.afterMatch(slice2, secondSlice);
+    string memory first = Strings.toString(firstSlice);
+    string memory second = Strings.toString(secondSlice);
+    string memory result = string(abi.encodePacked(first, Strings.uint2str(id), second));
+    return result;
   }
 
   /**
@@ -1032,23 +1016,6 @@ contract Super1155 is PermitControl, ERC165Storage, IERC1155, IERC1155MetadataUR
   }
 
   /**
-    Set the on-chain metadata attached to a specific token ID so long as the
-    collection as a whole or the token specifically has not had metadata
-    editing frozen.
-
-    @param _id The ID of the token to set the `_metadata` for.
-    @param _metadata The metadata string to store on-chain.
-  */
-  function setMetadata(uint256 _id, string memory _metadata)
-    external hasItemRight(_id, SET_METADATA) {
-    require(!uriLocked && !metadataFrozen[_id],
-      "Super1155: you cannot edit this metadata because it is frozen");
-    string memory oldMetadata = metadata[_id];
-    metadata[_id] = _metadata;
-    emit MetadataChanged(_msgSender(), _id, oldMetadata, _metadata);
-  }
-
-  /**
     Allow the item collection owner or an associated manager to forever lock the
     metadata URI on the entire collection to future changes.
 
@@ -1061,19 +1028,6 @@ contract Super1155 is PermitControl, ERC165Storage, IERC1155, IERC1155MetadataUR
     emit ChangeURI(oldURI, _uri);
     uriLocked = true;
     emit PermanentURI(_uri, 2 ** 256 - 1);
-  }
-
-  /**
-    Allow the item collection owner or an associated manager to forever lock the
-    metadata URI on an item to future changes.
-
-    @param _uri The value of the URI to lock for `_id`.
-    @param _id The token ID to lock a metadata URI value into.
-  */
-  function lockURI(string calldata _uri, uint256 _id) external
-    hasItemRight(_id, LOCK_ITEM_URI) {
-    metadataFrozen[_id] = true;
-    emit PermanentURI(_uri, _id);
   }
 
   /**

--- a/contracts/Super721.sol
+++ b/contracts/Super721.sol
@@ -1097,10 +1097,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   }
 
   function tokenURI(uint256 _tokenId) public view returns (string memory) {
-    return Strings.strConcat(
-        metadataUri,
-        Strings.uint2str(_tokenId),
-        ".json"
-    );
+    return metadata[_tokenId];
   }
 }

--- a/contracts/Super721.sol
+++ b/contracts/Super721.sol
@@ -17,15 +17,12 @@ import "./utils/LocalStrings.sol";
   @author Tim Clancy
   @author 0xthrpw
   @author Qazawat Zirak
-
   This contract represents the NFTs within a single collection. It allows for a
   designated collection owner address to manage the creation of NFTs within this
   collection. The collection owner grants approval to or removes approval from
   other addresses governing their ability to mint NFTs from this collection.
-
   This contract is forked from the inherited OpenZeppelin dependency, and uses
   ideas inherited from the Super721 reference implementation.
-
   August 4th, 2021.
 */
 contract Super721 is PermitControl, ERC165Storage, IERC721 {
@@ -145,7 +142,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     to do so may move from a more-permissive supply type to a less-permissive.
     For example: an uncapped or flexible supply type may be converted to a
     capped supply type. A capped supply type may not be uncapped later, however.
-
     @param Capped There exists a fixed cap on the size of the item group. The
       cap is set by `supplyData`.
     @param Uncapped There is no cap on the size of the item group. The value of
@@ -164,7 +160,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     This enumeration lists the various burn types that each item group may use.
     These are static once chosen.
-
     @param None The items in this group may not be burnt. The value of
       `burnData` is ignored.
     @param Burnable The items in this group may be burnt. The value of
@@ -181,7 +176,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     This struct is a source of mapping-free input to the `configureGroup`
     function. It defines the settings for a particular item group.
-
     @param name A name for the item group.
     @param supplyType The supply type for this group of items.
     @param supplyData An optional integer used by some `supplyType` values.
@@ -199,7 +193,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     This struct defines the settings for a particular item group and is tracked
     in storage.
-
     @param initialized Whether or not this `ItemGroup` has been initialized.
     @param name A name for the item group.
     @param supplyType The supply type for this group of items.
@@ -235,6 +228,23 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /// A mapping of the number of times each individual token has been burnt.
   mapping (uint256 => uint256) public burnCount;
 
+  /**
+    A mapping of token ID to a boolean representing whether the item's metadata
+    has been explicitly frozen via a call to `lockURI(string calldata _uri,
+    uint256 _id)`. Do note that it is possible for an item's mapping here to be
+    false while still having frozen metadata if the item collection as a whole
+    has had its `uriLocked` value set to true.
+  */
+  mapping (uint256 => bool) public metadataFrozen;
+
+  /**
+    A public mapping of optional on-chain metadata for each token ID. A token's
+    on-chain metadata is unable to be changed if the item's metadata URI has
+    been permanently fixed or if the collection's metadata URI as a whole has
+    been frozen.
+  */
+  mapping (uint256 => string) public metadata;
+
   /// Whether or not the metadata URI has been locked to future changes.
   bool public uriLocked;
 
@@ -243,7 +253,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
 
   /**
     An event that gets emitted when the metadata collection URI is changed.
-
     @param oldURI The old metadata URI.
     @param newURI The new metadata URI.
   */
@@ -251,7 +260,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
 
   /**
     An event that gets emitted when the proxy registry address is changed.
-
     @param oldRegistry The old proxy registry address.
     @param newRegistry The new proxy registry address.
   */
@@ -260,7 +268,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
 
   /**
     An event that gets emitted when an item group is configured.
-
     @param manager The caller who configured the item group `_groupId`.
     @param groupId The groupId being configured.
     @param newGroup The new group configuration.
@@ -271,14 +278,23 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     An event that gets emitted when the item collection is locked to further
     creation.
-
     @param locker The caller who locked the collection.
   */
   event CollectionLocked(address indexed locker);
 
   /**
-    An event that indicates we have set a permanent metadata URI for a token.
+    An event that gets emitted when a token ID has its on-chain metadata
+    changed.
+    @param changer The caller who triggered the metadata change.
+    @param id The ID of the token which had its metadata changed.
+    @param oldMetadata The old metadata of the token.
+    @param newMetadata The new metadata of the token.
+  */
+  event MetadataChanged(address indexed changer, uint256 indexed id,
+    string oldMetadata, string indexed newMetadata);
 
+  /**
+    An event that indicates we have set a permanent metadata URI for a token.
     @param _value The value of the permanent metadata URI.
     @param _id The token ID associated with the permanent metadata value.
   */
@@ -289,7 +305,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     with a specified valid right to perform a call on some specific item. Rights
     can be applied to the universal circumstance, the item-group-level
     circumstance, or to the circumstance of the item ID itself.
-
     @param _id The item ID on which we check for the validity of the specified
       `right`.
     @param _right The right to validate for the calling address. It must be
@@ -315,7 +330,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
 
   /**
     Construct a new ERC-721 item collection.
-
     @param _owner The address of the administrator governing this collection.
     @param _name The name to assign to this item collection contract.
     @param _uri The metadata URI to perform later token ID substitution with.
@@ -342,7 +356,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     proxyRegistryAddress = _proxyRegistryAddress;
   }
   /**
-
   */
   function ownerOf(uint256 tokenId) public view override returns (address) {
       return _tokenOwners.get(tokenId, "Super721::ownerOf: owner query for nonexistent token");
@@ -376,10 +389,9 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     said specification, clients calling this function must replace the {id}
     substring with the actual token ID in hex, not prefixed by 0x, and padded
     to 64 characters in length.
-
     @return The metadata URI string of the item with ID `_itemId`.
   */
- function uri(uint256 id) public view returns (string memory) {
+  function uri(uint256 id) external view returns (string memory) {
     Strings.Slice memory slice1 = metadataUri.toSlice();
     Strings.Slice memory slice2 = metadataUri.toSlice();
     string memory tokenFirst = "{";
@@ -399,7 +411,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     metadata URI of this collection. This implementation relies on a single URI
     for all items within the collection, and as such does not emit the standard
     URI event. Instead, we emit our own event to reflect changes in the URI.
-
     @param _uri The new URI to update to.
   */
   function setURI(string calldata _uri) external virtual
@@ -415,7 +426,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     Allow the item collection owner or an approved manager to update the proxy
     registry address handling delegated approval.
-
     @param _proxyRegistryAddress The address of the new proxy registry to
       update to.
   */
@@ -429,7 +439,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     Retrieve the balance of a particular token `_id` for a particular address
     `_owner`.
-
     @param _owner The owner to check for this token balance.
     @param _id The ID of the token to check for a balance.
     @return The amount of token `_id` owned by `_owner`.
@@ -452,7 +461,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     Retrieve in a single call the balances of some mulitple particular token
     `_ids` held by corresponding `_owners`.
-
     @param _owners The owners to check for token balances.
     @param _ids The IDs of tokens to check for balances.
     @return the amount of each token owned by each owner.
@@ -474,7 +482,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     This function returns true if `_operator` is approved to transfer items
     owned by `_owner`. This approval check features an override to explicitly
     whitelist any addresses delegated in the proxy registry.
-
     @param _owner The owner of items to check for transfer ability.
     @param _operator The potential transferrer of `_owner`'s items.
     @return Whether `_operator` may transfer items owned by `_owner`.
@@ -493,7 +500,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     Enable or disable approval for a third party `_operator` address to manage
     (transfer or burn) all of the caller's tokens.
-
     @param _operator The address to grant management rights over all of the
       caller's tokens.
     @param _approved The status of the `_operator`'s approval for the caller.
@@ -508,7 +514,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
 
   /**
     This private helper function converts a number into a single-element array.
-
     @param _element The element to convert to an array.
     @return The array containing the single `_element`.
   */
@@ -522,7 +527,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     An inheritable and configurable pre-transfer hook that can be overridden.
     It fires before any token transfer, including mints and burns.
-
     @param _operator The caller who triggers the token transfer.
     @param _from The address to transfer tokens from.
     @param _to The address to transfer tokens to.
@@ -539,7 +543,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     ERC-721 dictates that any contract which wishes to receive ERC-721 tokens
     must explicitly designate itself as such. This function checks for such
     designation to prevent undesirable token transfers.
-
     @param _operator The caller who triggers the token transfer.
     @param _from The address to transfer tokens from.
     @param _to The address to transfer tokens to.
@@ -565,7 +568,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     Transfer on behalf of a caller or one of their authorized token managers
     items from one address to another.
-
     @param _from The address to transfer tokens from.
     @param _to The address to transfer tokens to.
     @param _id The specific token ID to transfer.
@@ -622,7 +624,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     Transfer on behalf of a caller or one of their authorized token managers
     items from one address to another.
-
     @param _from The address to transfer tokens from.
     @param _to The address to transfer tokens to.
     @param _ids The specific token IDs to transfer.
@@ -664,7 +665,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     group share a group ID in the upper 128-bits of their full item ID.
     Within a group NFTs can be distinguished for the purposes of serializing
     issue numbers.
-
     @param _groupId The ID of the item group to create or configure.
     @param _data The `ItemGroup` data input.
   */
@@ -721,7 +721,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     This is a private helper function to replace the `hasItemRight` modifier
     that we use on some functions in order to inline this check during batch
     minting and burning.
-
     @param _id The ID of the item to check for the given `_right` on.
     @param _right The right that the caller is trying to exercise on `_id`.
     @return Whether or not the caller has a valid right on this item.
@@ -749,7 +748,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     This is a private helper function to verify, according to all of our various
     minting and burning rules, whether it would be valid to mint a particular
     item `_id`.
-
     @param _id The ID of the item to check for minting validity.
     @return The ID of the item that should be minted.
   */
@@ -789,7 +787,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     address. In order to mint an item, its item group must first have been
     created. Minting an item must obey both the fungibility and size cap of its
     group.
-
     @param _recipient The address to receive all NFTs within the newly-minted
       group.
     @param _ids The item IDs for the new items to create.
@@ -843,7 +840,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     This is a private helper function to verify, according to all of our various
     minting and burning rules, whether it would be valid to burn some `_amount`
     of a particular item `_id`.
-
     @param _id The ID of the item to check for burning validity.
     @return The ID of the item that should have `_amount` burnt for it.
   */
@@ -877,7 +873,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
 
   /**
     This function allows an address to destroy some of its items.
-
     @param _burner The address whose item is burning.
     @param _id The item ID to burn.
     @param _amount The amount of the corresponding item ID to burn.
@@ -918,7 +913,6 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
   /**
     This function allows an address to destroy multiple different items in a
     single call.
-
     @param _burner The address whose items are burning.
     @param _ids The item IDs to burn.
   */
@@ -966,11 +960,26 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     }
   }
 
+  /**
+    Set the on-chain metadata attached to a specific token ID so long as the
+    collection as a whole or the token specifically has not had metadata
+    editing frozen.
+    @param _id The ID of the token to set the `_metadata` for.
+    @param _metadata The metadata string to store on-chain.
+  */
+  function setMetadata(uint256 _id, string memory _metadata)
+    external hasItemRight(_id, SET_METADATA) {
+    uint groupId = _id >> 128;
+    require(!uriLocked && !metadataFrozen[_id] &&  !metadataFrozen[groupId],
+      "Super721::setMetadata: you cannot edit this metadata because it is frozen");
+    string memory oldMetadata = metadata[_id];
+    metadata[_id] = _metadata;
+    emit MetadataChanged(_msgSender(), _id, oldMetadata, _metadata);
+  }
 
   /**
     Allow the item collection owner or an associated manager to forever lock the
     metadata URI on the entire collection to future changes.
-
     @param _uri The value of the URI to lock for `_id`.
   */
   function lockURI(string calldata _uri) external
@@ -980,6 +989,31 @@ contract Super721 is PermitControl, ERC165Storage, IERC721 {
     emit ChangeURI(oldURI, _uri);
     uriLocked = true;
     emit PermanentURI(_uri, 2 ** 256 - 1);
+  }
+
+  /**
+    Allow the item collection owner or an associated manager to forever lock the
+    metadata URI on an item to future changes.
+    @param _uri The value of the URI to lock for `_id`.
+    @param _id The token ID to lock a metadata URI value into.
+  */
+  function lockItemURI(string calldata _uri, uint256 _id) external
+    hasItemRight(_id, LOCK_ITEM_URI) {
+    metadataFrozen[_id] = true;
+    emit PermanentURI(_uri, _id);
+  }
+
+  /**
+    Allow the item collection owner or an associated manager to forever lock the
+    metadata URI on a group of items to future changes.
+
+    @param _uri The value of the URI to lock for `groupId`.
+    @param groupId The group ID to lock a metadata URI value into.
+  */
+  function lockGroupURI(string calldata _uri, uint256 groupId) external
+    hasItemRight(groupId, LOCK_ITEM_URI) {
+    metadataFrozen[groupId] = true;
+    emit PermanentURI(_uri, groupId);
   }
 
   /**

--- a/contracts/Super721IMX.sol
+++ b/contracts/Super721IMX.sol
@@ -1111,11 +1111,7 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
       return tokenId;
   }
 
-  function tokenURI(uint256 _tokenId) public view returns (string memory) {
-    return Strings.strConcat(
-        metadataUri,
-        Strings.uint2str(_tokenId),
-        ".json"
-    );
+function tokenURI(uint256 _tokenId) public view returns (string memory) {
+    return metadata[_tokenId];
   }
 }

--- a/contracts/Super721IMX.sol
+++ b/contracts/Super721IMX.sol
@@ -17,15 +17,12 @@ import "./utils/LocalStrings.sol";
   @author Tim Clancy
   @author 0xthrpw
   @author Qazawat Zirak
-
   This contract represents the NFTs within a single collection. It allows for a
   designated collection owner address to manage the creation of NFTs within this
   collection. The collection owner grants approval to or removes approval from
   other addresses governing their ability to mint NFTs from this collection.
-
   This contract is forked from the inherited OpenZeppelin dependency, and uses
   ideas inherited from the Super721 reference implementation.
-
   August 4th, 2021.
 */
 contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
@@ -148,7 +145,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     to do so may move from a more-permissive supply type to a less-permissive.
     For example: an uncapped or flexible supply type may be converted to a
     capped supply type. A capped supply type may not be uncapped later, however.
-
     @param Capped There exists a fixed cap on the size of the item group. The
       cap is set by `supplyData`.
     @param Uncapped There is no cap on the size of the item group. The value of
@@ -167,7 +163,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     This enumeration lists the various burn types that each item group may use.
     These are static once chosen.
-
     @param None The items in this group may not be burnt. The value of
       `burnData` is ignored.
     @param Burnable The items in this group may be burnt. The value of
@@ -184,7 +179,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     This struct is a source of mapping-free input to the `configureGroup`
     function. It defines the settings for a particular item group.
-
     @param name A name for the item group.
     @param supplyType The supply type for this group of items.
     @param supplyData An optional integer used by some `supplyType` values.
@@ -202,7 +196,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     This struct defines the settings for a particular item group and is tracked
     in storage.
-
     @param initialized Whether or not this `ItemGroup` has been initialized.
     @param name A name for the item group.
     @param supplyType The supply type for this group of items.
@@ -238,6 +231,23 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /// A mapping of the number of times each individual token has been burnt.
   mapping (uint256 => uint256) public burnCount;
 
+  /**
+    A mapping of token ID to a boolean representing whether the item's metadata
+    has been explicitly frozen via a call to `lockURI(string calldata _uri,
+    uint256 _id)`. Do note that it is possible for an item's mapping here to be
+    false while still having frozen metadata if the item collection as a whole
+    has had its `uriLocked` value set to true.
+  */
+  mapping (uint256 => bool) public metadataFrozen;
+
+  /**
+    A public mapping of optional on-chain metadata for each token ID. A token's
+    on-chain metadata is unable to be changed if the item's metadata URI has
+    been permanently fixed or if the collection's metadata URI as a whole has
+    been frozen.
+  */
+  mapping (uint256 => string) public metadata;
+
   /// Whether or not the metadata URI has been locked to future changes.
   bool public uriLocked;
 
@@ -246,7 +256,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
 
   /**
     An event that gets emitted when the metadata collection URI is changed.
-
     @param oldURI The old metadata URI.
     @param newURI The new metadata URI.
   */
@@ -254,7 +263,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
 
   /**
     An event that gets emitted when the proxy registry address is changed.
-
     @param oldRegistry The old proxy registry address.
     @param newRegistry The new proxy registry address.
   */
@@ -263,7 +271,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
 
   /**
     An event that gets emitted when an item group is configured.
-
     @param manager The caller who configured the item group `_groupId`.
     @param groupId The groupId being configured.
     @param newGroup The new group configuration.
@@ -274,14 +281,23 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     An event that gets emitted when the item collection is locked to further
     creation.
-
     @param locker The caller who locked the collection.
   */
   event CollectionLocked(address indexed locker);
 
   /**
-    An event that indicates we have set a permanent metadata URI for a token.
+    An event that gets emitted when a token ID has its on-chain metadata
+    changed.
+    @param changer The caller who triggered the metadata change.
+    @param id The ID of the token which had its metadata changed.
+    @param oldMetadata The old metadata of the token.
+    @param newMetadata The new metadata of the token.
+  */
+  event MetadataChanged(address indexed changer, uint256 indexed id,
+    string oldMetadata, string indexed newMetadata);
 
+  /**
+    An event that indicates we have set a permanent metadata URI for a token.
     @param _value The value of the permanent metadata URI.
     @param _id The token ID associated with the permanent metadata value.
   */
@@ -292,7 +308,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     with a specified valid right to perform a call on some specific item. Rights
     can be applied to the universal circumstance, the item-group-level
     circumstance, or to the circumstance of the item ID itself.
-
     @param _id The item ID on which we check for the validity of the specified
       `right`.
     @param _right The right to validate for the calling address. It must be
@@ -318,7 +333,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
 
   /**
     Construct a new ERC-721 item collection.
-
     @param _owner The address of the administrator governing this collection.
     @param _name The name to assign to this item collection contract.
     @param _uri The metadata URI to perform later token ID substitution with.
@@ -347,7 +361,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     imxCoreAddress = _imxCoreAddress;
   }
   /**
-
   */
   function ownerOf(uint256 tokenId) public view override returns (address) {
       return _tokenOwners.get(tokenId, "Super721::ownerOf: owner query for nonexistent token");
@@ -381,10 +394,9 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     said specification, clients calling this function must replace the {id}
     substring with the actual token ID in hex, not prefixed by 0x, and padded
     to 64 characters in length.
-
     @return The metadata URI string of the item with ID `_itemId`.
   */
-  function uri(uint256 id) public view returns (string memory) {
+  function uri(uint256 id) external view returns (string memory) {
     Strings.Slice memory slice1 = metadataUri.toSlice();
     Strings.Slice memory slice2 = metadataUri.toSlice();
     string memory tokenFirst = "{";
@@ -404,7 +416,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     metadata URI of this collection. This implementation relies on a single URI
     for all items within the collection, and as such does not emit the standard
     URI event. Instead, we emit our own event to reflect changes in the URI.
-
     @param _uri The new URI to update to.
   */
   function setURI(string calldata _uri) external virtual
@@ -420,7 +431,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     Allow the item collection owner or an approved manager to update the proxy
     registry address handling delegated approval.
-
     @param _proxyRegistryAddress The address of the new proxy registry to
       update to.
   */
@@ -434,7 +444,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     Retrieve the balance of a particular token `_id` for a particular address
     `_owner`.
-
     @param _owner The owner to check for this token balance.
     @param _id The ID of the token to check for a balance.
     @return The amount of token `_id` owned by `_owner`.
@@ -457,7 +466,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     Retrieve in a single call the balances of some mulitple particular token
     `_ids` held by corresponding `_owners`.
-
     @param _owners The owners to check for token balances.
     @param _ids The IDs of tokens to check for balances.
     @return the amount of each token owned by each owner.
@@ -479,7 +487,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     This function returns true if `_operator` is approved to transfer items
     owned by `_owner`. This approval check features an override to explicitly
     whitelist any addresses delegated in the proxy registry.
-
     @param _owner The owner of items to check for transfer ability.
     @param _operator The potential transferrer of `_owner`'s items.
     @return Whether `_operator` may transfer items owned by `_owner`.
@@ -498,7 +505,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     Enable or disable approval for a third party `_operator` address to manage
     (transfer or burn) all of the caller's tokens.
-
     @param _operator The address to grant management rights over all of the
       caller's tokens.
     @param _approved The status of the `_operator`'s approval for the caller.
@@ -513,7 +519,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
 
   /**
     This private helper function converts a number into a single-element array.
-
     @param _element The element to convert to an array.
     @return The array containing the single `_element`.
   */
@@ -527,7 +532,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     An inheritable and configurable pre-transfer hook that can be overridden.
     It fires before any token transfer, including mints and burns.
-
     @param _operator The caller who triggers the token transfer.
     @param _from The address to transfer tokens from.
     @param _to The address to transfer tokens to.
@@ -544,7 +548,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     ERC-721 dictates that any contract which wishes to receive ERC-721 tokens
     must explicitly designate itself as such. This function checks for such
     designation to prevent undesirable token transfers.
-
     @param _operator The caller who triggers the token transfer.
     @param _from The address to transfer tokens from.
     @param _to The address to transfer tokens to.
@@ -570,7 +573,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     Transfer on behalf of a caller or one of their authorized token managers
     items from one address to another.
-
     @param _from The address to transfer tokens from.
     @param _to The address to transfer tokens to.
     @param _id The specific token ID to transfer.
@@ -627,7 +629,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     Transfer on behalf of a caller or one of their authorized token managers
     items from one address to another.
-
     @param _from The address to transfer tokens from.
     @param _to The address to transfer tokens to.
     @param _ids The specific token IDs to transfer.
@@ -669,7 +670,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     group share a group ID in the upper 128-bits of their full item ID.
     Within a group NFTs can be distinguished for the purposes of serializing
     issue numbers.
-
     @param _groupId The ID of the item group to create or configure.
     @param _data The `ItemGroup` data input.
   */
@@ -726,7 +726,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     This is a private helper function to replace the `hasItemRight` modifier
     that we use on some functions in order to inline this check during batch
     minting and burning.
-
     @param _id The ID of the item to check for the given `_right` on.
     @param _right The right that the caller is trying to exercise on `_id`.
     @return Whether or not the caller has a valid right on this item.
@@ -754,7 +753,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     This is a private helper function to verify, according to all of our various
     minting and burning rules, whether it would be valid to mint a particular
     item `_id`.
-
     @param _id The ID of the item to check for minting validity.
     @return The ID of the item that should be minted.
   */
@@ -794,7 +792,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     address. In order to mint an item, its item group must first have been
     created. Minting an item must obey both the fungibility and size cap of its
     group.
-
     @param _recipient The address to receive all NFTs within the newly-minted
       group.
     @param _ids The item IDs for the new items to create.
@@ -858,7 +855,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     This is a private helper function to verify, according to all of our various
     minting and burning rules, whether it would be valid to burn some `_amount`
     of a particular item `_id`.
-
     @param _id The ID of the item to check for burning validity.
     @return The ID of the item that should have `_amount` burnt for it.
   */
@@ -892,7 +888,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
 
   /**
     This function allows an address to destroy some of its items.
-
     @param _burner The address whose item is burning.
     @param _id The item ID to burn.
     @param _amount The amount of the corresponding item ID to burn.
@@ -933,7 +928,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /**
     This function allows an address to destroy multiple different items in a
     single call.
-
     @param _burner The address whose items are burning.
     @param _ids The item IDs to burn.
   */
@@ -982,9 +976,25 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   }
 
   /**
+    Set the on-chain metadata attached to a specific token ID so long as the
+    collection as a whole or the token specifically has not had metadata
+    editing frozen.
+    @param _id The ID of the token to set the `_metadata` for.
+    @param _metadata The metadata string to store on-chain.
+  */
+  function setMetadata(uint256 _id, string memory _metadata)
+    external hasItemRight(_id, SET_METADATA) {
+    uint groupId = _id >> 128;
+    require(!uriLocked && !metadataFrozen[_id] &&  !metadataFrozen[groupId],
+      "Super721::setMetadata: you cannot edit this metadata because it is frozen");
+    string memory oldMetadata = metadata[_id];
+    metadata[_id] = _metadata;
+    emit MetadataChanged(_msgSender(), _id, oldMetadata, _metadata);
+  }
+
+  /**
     Allow the item collection owner or an associated manager to forever lock the
     metadata URI on the entire collection to future changes.
-
     @param _uri The value of the URI to lock for `_id`.
   */
   function lockURI(string calldata _uri) external
@@ -994,6 +1004,31 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     emit ChangeURI(oldURI, _uri);
     uriLocked = true;
     emit PermanentURI(_uri, 2 ** 256 - 1);
+  }
+
+  /**
+    Allow the item collection owner or an associated manager to forever lock the
+    metadata URI on an item to future changes.
+    @param _uri The value of the URI to lock for `_id`.
+    @param _id The token ID to lock a metadata URI value into.
+  */
+  function lockItemURI(string calldata _uri, uint256 _id) external
+    hasItemRight(_id, LOCK_ITEM_URI) {
+    metadataFrozen[_id] = true;
+    emit PermanentURI(_uri, _id);
+  }
+
+  /**
+    Allow the item collection owner or an associated manager to forever lock the
+    metadata URI on a group of items to future changes.
+
+    @param _uri The value of the URI to lock for `groupId`.
+    @param groupId The group ID to lock a metadata URI value into.
+  */
+  function lockGroupURI(string calldata _uri, uint256 groupId) external
+    hasItemRight(groupId, LOCK_ITEM_URI) {
+    metadataFrozen[groupId] = true;
+    emit PermanentURI(_uri, groupId);
   }
 
   /**
@@ -1064,4 +1099,5 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
       (uint256 tokenId, ) = _tokenOwners.at(index);
       return tokenId;
   }
+
 }

--- a/contracts/Super721IMX.sol
+++ b/contracts/Super721IMX.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "./utils/LocalStrings.sol";
 import "./access/PermitControl.sol";
 import "./proxy/StubProxyRegistry.sol";
+import "./utils/LocalStrings.sol";
 
 /**
   @title An ERC-721 item creation contract.
@@ -29,6 +30,7 @@ import "./proxy/StubProxyRegistry.sol";
 */
 contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   using Address for address;
+  using Strings for string;
   using EnumerableSet for EnumerableSet.UintSet;
   using EnumerableMap for EnumerableMap.UintToAddressMap;
 
@@ -236,23 +238,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   /// A mapping of the number of times each individual token has been burnt.
   mapping (uint256 => uint256) public burnCount;
 
-  /**
-    A mapping of token ID to a boolean representing whether the item's metadata
-    has been explicitly frozen via a call to `lockURI(string calldata _uri,
-    uint256 _id)`. Do note that it is possible for an item's mapping here to be
-    false while still having frozen metadata if the item collection as a whole
-    has had its `uriLocked` value set to true.
-  */
-  mapping (uint256 => bool) public metadataFrozen;
-
-  /**
-    A public mapping of optional on-chain metadata for each token ID. A token's
-    on-chain metadata is unable to be changed if the item's metadata URI has
-    been permanently fixed or if the collection's metadata URI as a whole has
-    been frozen.
-  */
-  mapping (uint256 => string) public metadata;
-
   /// Whether or not the metadata URI has been locked to future changes.
   bool public uriLocked;
 
@@ -293,18 +278,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     @param locker The caller who locked the collection.
   */
   event CollectionLocked(address indexed locker);
-
-  /**
-    An event that gets emitted when a token ID has its on-chain metadata
-    changed.
-
-    @param changer The caller who triggered the metadata change.
-    @param id The ID of the token which had its metadata changed.
-    @param oldMetadata The old metadata of the token.
-    @param newMetadata The new metadata of the token.
-  */
-  event MetadataChanged(address indexed changer, uint256 indexed id,
-    string oldMetadata, string indexed newMetadata);
 
   /**
     An event that indicates we have set a permanent metadata URI for a token.
@@ -411,8 +384,19 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
 
     @return The metadata URI string of the item with ID `_itemId`.
   */
-  function uri(uint256) external view returns (string memory) {
-    return metadataUri;
+  function uri(uint256 id) public view returns (string memory) {
+    Strings.Slice memory slice1 = metadataUri.toSlice();
+    Strings.Slice memory slice2 = metadataUri.toSlice();
+    string memory tokenFirst = "{";
+    string memory tokenLast = "}";
+    Strings.Slice memory firstSlice = tokenFirst.toSlice();
+    Strings.Slice memory secondSlice = tokenLast.toSlice();
+    firstSlice = Strings.beforeMatch(slice1, firstSlice);
+    secondSlice = Strings.afterMatch(slice2, secondSlice);
+    string memory first = Strings.toString(firstSlice);
+    string memory second = Strings.toString(secondSlice);
+    string memory result = string(abi.encodePacked(first, Strings.uint2str(id), second));
+    return result;
   }
 
   /**
@@ -998,23 +982,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   }
 
   /**
-    Set the on-chain metadata attached to a specific token ID so long as the
-    collection as a whole or the token specifically has not had metadata
-    editing frozen.
-
-    @param _id The ID of the token to set the `_metadata` for.
-    @param _metadata The metadata string to store on-chain.
-  */
-  function setMetadata(uint256 _id, string memory _metadata)
-    external hasItemRight(_id, SET_METADATA) {
-    require(!uriLocked && !metadataFrozen[_id],
-      "Super721::setMetadata: you cannot edit this metadata because it is frozen");
-    string memory oldMetadata = metadata[_id];
-    metadata[_id] = _metadata;
-    emit MetadataChanged(_msgSender(), _id, oldMetadata, _metadata);
-  }
-
-  /**
     Allow the item collection owner or an associated manager to forever lock the
     metadata URI on the entire collection to future changes.
 
@@ -1027,19 +994,6 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
     emit ChangeURI(oldURI, _uri);
     uriLocked = true;
     emit PermanentURI(_uri, 2 ** 256 - 1);
-  }
-
-  /**
-    Allow the item collection owner or an associated manager to forever lock the
-    metadata URI on an item to future changes.
-
-    @param _uri The value of the URI to lock for `_id`.
-    @param _id The token ID to lock a metadata URI value into.
-  */
-  function lockItemGroupURI(string calldata _uri, uint256 _id) external
-    hasItemRight(_id, LOCK_ITEM_URI) {
-    metadataFrozen[_id] = true;
-    emit PermanentURI(_uri, _id);
   }
 
   /**
@@ -1109,9 +1063,5 @@ contract Super721IMX is PermitControl, ERC165Storage, IERC721 {
   function tokenByIndex(uint256 index) public view returns (uint256) {
       (uint256 tokenId, ) = _tokenOwners.at(index);
       return tokenId;
-  }
-
-function tokenURI(uint256 _tokenId) public view returns (string memory) {
-    return metadata[_tokenId];
   }
 }

--- a/contracts/utils/LocalStrings.sol
+++ b/contracts/utils/LocalStrings.sol
@@ -71,8 +71,8 @@ library Strings {
         uint mask = 256 ** (32 - _length) - 1;
         assembly {
             let source := and(mload(_source), not(mask))
-            let _destinationination := and(mload(_destination), mask)
-            mstore(_destination, or(_destinationination, source))
+            let destination := and(mload(_destination), mask)
+            mstore(_destination, or(destination, source))
         }
     }
 


### PR DESCRIPTION
Changed returning metadata from concatenating values in memory to reading mapping value.

Questions:
1) Could there be different formats for url metadata to store on the contract?
2) Can a collection have metadata stored on different domains and have different url path?

Suggestions:
1) Rework the commentaries, they see to be outdated.
2) Add actual check if ItemGroup has been frozen before changing metadata.